### PR TITLE
[CI] Ignore certain paths in site deployment workflow

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -6,7 +6,9 @@ on:
   push:
     branches:
       - master
-
+    paths:
+      - '!**'
+      - 'docs/**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -7,8 +7,8 @@ on:
     branches:
       - master
     paths:
-      - '!**'
-      - 'docs/**'
+      - '!.github/**'
+      - '!archive/**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Ignore these paths (no build needed):

paths:
      - '!**'
      - 'docs/**'




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
