### PR TITLE
Unwanted empty space in the navigation fix

### DIFF
--- a/content/en/cloud/security/permissions.md
+++ b/content/en/cloud/security/permissions.md
@@ -1,4 +1,4 @@
-<!-- ---
+---
 title: Permissions
 description: >
   A short lead description about this content page. It can be **bold** or _italic_ and can be split over multiple paragraphs.
@@ -6,6 +6,7 @@ date: 2023-10-30
 # weight: 5
 categories: [Security]
 tags: [permissions]
+draft: true
 ---
 
 
@@ -234,4 +235,4 @@ Stumptown PBR&B keytar plaid street art, forage XOXO pitchfork selvage affogato 
 
 ```
 This is the final element on the page and there should be no margin below this.
-``` --> -->
+``` -->


### PR DESCRIPTION
**Notes for Reviewers**

The Security permission page is leading to empty space in the navigation.
![image](https://github.com/layer5io/docs/assets/74408634/e77bcf09-6a0b-4a25-a25e-18b510954fdc)

I fixed this by uncommenting the markdown and adding draft: true to ensure that the page is not available in production.



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
