### PR TITLE
Added Partial for Layer5 plans

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -7,6 +7,9 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
+	{{ with .Params.plan }}
+        {{ partial "plan-info.html" (dict "plan" .) }}
+    {{ end }}
 	{{ .Content }}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
 		<br />

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -8,6 +8,9 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
+	{{ with .Params.plan }}
+        {{ partial "plan-info.html" (dict "plan" .) }}
+    {{ end }}
 	{{ .Content }}
   {{ partial "section-index.html" . -}}
 	

--- a/layouts/partials/plan-info.html
+++ b/layouts/partials/plan-info.html
@@ -1,0 +1,75 @@
+{{ $plan := .plan }}
+
+<style>
+    .bwnekH {
+    border-radius: 10px;
+    border-style: solid;
+    border-color: #00b39f;
+    padding: 16px;
+    margin-left:6rem;
+    margin-right:6rem;
+    margin-bottom:2rem;
+}
+
+.f4 {
+    font-size: 16px !important;
+}
+
+.d-inline-block {
+    display: inline-block !important;
+}
+
+.mb-3 {
+    margin-bottom: 16px !important;
+}
+
+.d-flex {
+    display: flex !important;
+}
+
+.mt-1 {
+    margin-right:4px;
+}
+</style>
+
+<div class="Box-sc-g0xbh4-0 bwnekH">
+    <div data-search="hide" data-testid="permissions-callout">
+        <div class="mb-3 d-inline-block">
+            <h2 class="f4">Who can use this feature?</h2>
+        </div>
+        <div class="d-flex" data-testid="product-statement"><svg aria-hidden="true" focusable="false" class="mt-1"
+                viewBox="0 0 16 16" width="16" height="16" fill="currentColor"
+                style="display:inline-block;user-select:none;vertical-align:text-bottom;overflow:visible">
+                <path
+                    d="M6.75 0h2.5C10.216 0 11 .784 11 1.75V3h3.25c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25v-8.5C0 3.784.784 3 1.75 3H5V1.75C5 .784 5.784 0 6.75 0ZM3.5 9.5a3.49 3.49 0 0 1-2-.627v4.377c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V8.873a3.49 3.49 0 0 1-2 .627Zm-1.75-5a.25.25 0 0 0-.25.25V6a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V4.75a.25.25 0 0 0-.25-.25H1.75ZM9.5 3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25V3Z">
+                </path>
+            </svg>
+            <div class="pl-2">
+                <p>Layer5 is available with Free, Team and Enterprise plans. For more information, see "<a
+                        href="https://layer5.io/pricing"
+                        _originalhref="https://layer5.io/pricing"
+                        aria-roledescription="hovercard link" aria-describedby="popover-describedby">Layer5’s
+                        plans</a>."</p>
+                        
+                        {{ if eq $plan "free" }}
+
+                        <div>
+                            <p>If you have a <b>Free subscription</b>, you get Open Source features, plus Cloud Native Design Patterns, Design Reviews, Multiple Kubernetes Clusters, Cluster Discovery, Microservices Performance, Load Generation, Open Policy Agent integration, Continuous Service Monitoring, Community Support, etc.</p>
+                        </div>
+                        {{ else if eq $plan "team" }}
+                        <div>
+                            <p>If you have a <b>Team subscription</b>, you get everything in the Free plan, plus Dry-run, Design Reviews, Visual Design, Design Versioning, Performance Profiles, Built-in Roles, Comparative Testing, Standard Support, Add-ons, etc.</p>
+                        </div>
+                        {{ else if eq $plan "enterprise" }}
+                        <div>
+                            <p>If you have an <b>Enterprise subscription</b>, you get everything in the Team plan, plus User-defined Roles, Authentication: LDAP, Self-hosted Deployment, Traffic Replay, Certificate support in performance profiles, Phone Support, Organization and Team Management, Premium and Premium Plus Support, Serverless Pricing, etc.</p>
+                        </div>
+                        {{ else }}
+                        <div>
+                            <p>If you have a <b>Free subscription</b>, you get Open Source features, plus Cloud Native Design Patterns, Design Reviews, Multiple Kubernetes Clusters, Cluster Discovery, Microservices Performance, Load Generation, Open Policy Agent integration, Continuous Service Monitoring, Community Support, etc.</p>
+                        </div>
+                        {{ end }}
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
use this custom frontmatter variable to display a plan info section
`plan: free `
`plan: team`
`plan: enterprise`

plan: free
![image](https://github.com/layer5io/docs/assets/74408634/ebeb90da-02ae-403a-a5b4-a6056ea58b4a)
plan: team
![image](https://github.com/layer5io/docs/assets/74408634/da165be1-3c56-4c83-adcf-9ea969f524e6)
plan: enterprise
![image](https://github.com/layer5io/docs/assets/74408634/f51cc9a8-d0a8-4d80-82ff-66a942a76510)



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
