### PR TITLE
Fix Broken hyperlink - embedding designs Issue#343

### DIFF
--- a/content/en/meshmap/designer/export-designs/_index.md
+++ b/content/en/meshmap/designer/export-designs/_index.md
@@ -44,4 +44,4 @@ If your design was generated from a source like HelmChart, Kubernetes manifest, 
 ## Exporting as Embedding
 
 Exporting your design as an embedding allows you to integrate it into websites, blogs, or other platforms that support HTML, CSS, and JavaScript. The embedded design version offers a visually interactive representation of your design, making it easy to share with infrastructure stakeholders.
-[Learn more](embedding-designs) about Embedding Designs.
+[Learn more](../embedding-designs) about Embedding Designs.


### PR DESCRIPTION
Signed-off-by: Kaushik Tak <kaushiktak19@gmail.com>
#343

**Notes for Reviewers**

This PR fixes #343




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
Hyperlink was not working for "learn more" in Exporting designs page because link to embedding designs was not correct. This PR solved that issue by adding correct location/link for the same.