### PR TITLE
Use of `Google Analytics 4 (GA4)` id

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -56,7 +56,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "G-HX135VWX9B"
 
 # Language configuration
 


### PR DESCRIPTION
**Notes for Reviewers**

Universal Analytics (UA): Google officially stopped processing new data in Universal Analytics. So, UA is now deprecated and no longer supported for new data collection.
Google Analytics 4 (GA4): GA4 is the latest version of Google Analytics, and it is now the default tracking platform. 



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
