### PR TITLE
add Sitemap Generation to Hugo Build Process

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -56,7 +56,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "G-HX135VWX9B"
+id = "UA-00000000-0"
 
 # Language configuration
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -56,7 +56,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "G-HX135VWX9B"
 
 # Language configuration
 
@@ -86,7 +86,15 @@ description = "Product Documentation"
 
 # Comment out if you don't want the "print entire section" link enabled.
 [outputs]
-# section = ["HTML", "print", "RSS"]
+  home = ["HTML", "RSS", "SITEMAP"]
+  section = ["HTML", "RSS"]
+  taxonomy = ["HTML", "RSS"]
+  taxonomyTerm = ["HTML", "RSS"]
+
+[sitemap]
+  changefreq = "daily"
+  priority = 0.5
+  filename = "sitemap.xml"
 
 [params]
 copyright = "Layer5 Authors"


### PR DESCRIPTION
**Notes for Reviewers**

This PR configured the Hugo site to generate a sitemap.xml file during each build and informs the search engines to check the sitemap in daily basis by updating the [outputs] and [sitemap] sections in hugo.toml.




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
