### PR TITLE
disable modal for images with data-modal="false" in docs pages

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,14 +6,14 @@
             <div class="col-lg-6">
                 <a href="/">
                     {{ $svg := resources.Get "icons/logo.svg" }}
-                    <img class="footer-logo" src="{{ $svg.Permalink }}" alt="Footer Logo Layer5">
+                    <img class="footer-logo" src="{{ $svg.Permalink }}" alt="Footer Logo Layer5" data-modal="false">
                 </a>
             </div>
             <div class="col-lg-6 footer-info footer-icons">
                 {{ range .Site.Params.links.footer.icons }}
                 <a href="{{ .url  }}" class="{{ .class }}" target="_blank" rel="noreferrer">
                     {{ $svg1 := resources.Get .icon }}
-                    <img height="30px"  src="{{ $svg1.Permalink }}" alt="{{ .alt }}">
+                    <img height="30px"  src="{{ $svg1.Permalink }}" alt="{{ .alt }}" data-modal="false">
                 </a>
                 {{ end }}
             </div>

--- a/layouts/partials/image-modal.html
+++ b/layouts/partials/image-modal.html
@@ -25,7 +25,6 @@ function openModal(imageIdOrElement) {
 
   document.getElementById("modalPic").src = src;
   document.getElementById("myModal").style.display = "block";
-  document.getElementById("site-footer").style.display = "hidden";
 }
 
 
@@ -33,7 +32,6 @@ function openModal(imageIdOrElement) {
 function closeModal() { 
   document.getElementById("modalPic").src = "";
   document.getElementById("myModal").style.display = "none";
-  document.getElementById("site-footer").style.display = "block";
 }
 
 </script>

--- a/layouts/partials/image-modal.html
+++ b/layouts/partials/image-modal.html
@@ -44,7 +44,9 @@ function closeModal() {
     var imgTags = document.querySelectorAll("img");
     imgTags.forEach(function (img) {
       img.onclick = function () {
-        openModal(img);
+        if (img.dataset.modal !== "false") {
+                openModal(img);
+            }
       };
     });
   });

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -51,7 +51,7 @@
             data-toggle="dropdown"
             style="padding-top:6px"
             >
-            <img width="28px" src="/images/grid-icon.svg" class="grid-icon" />
+            <img width="28px" src="/images/grid-icon.svg" class="grid-icon" data-modal="false" />
 
           </div>
           <div class="dropdown-menu" aria-labelledby="productsDropdown" style="margin-left:-4.5rem;visibility:hidden;">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -6,7 +6,7 @@
       <a class="navbar-brand" href="/">
         <span class="navbar-brand__logo navbar-logo">
           {{ $svg := resources.Get "icons/logo.svg" }}
-          <img class="footer-logo" src="/images/logo.svg" alt="logo" />
+          <img class="footer-logo" src="/images/logo.svg" alt="logo" data-modal="false" />
         </span>
         <span class="navbar-brand__name"></span
       ></a>


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes 
![image](https://github.com/user-attachments/assets/5a6d1214-4be7-4e39-aa6d-c66734a795f7)

- currently, all imgs are opened in modal on pages using docs layout causing the nav grid icon to malfunction, the pr prevents this behaviour for imgs that have data-modal attribute set as false ( we an just set the attribute for such other opt-out icons as well)



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
