### PR TITLE
Feature workflow typo fixed

### DIFF
--- a/.github/workflows/feature-list.yml
+++ b/.github/workflows/feature-list.yml
@@ -27,7 +27,7 @@ jobs:
             const { data: sourceFile } = await github.rest.repos.getContent({
               owner: 'layer5labs',
               repo: 'meshery-extensions-packages',
-              path: 'feature-data.json',
+              path: 'feature_data.json',
               ref: 'master'
             });
             


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes supersedes [this](https://github.com/layer5io/docs/pull/379) PR  fixing a typo in workflow




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
