### PR TITLE
Improve Lightbox: Escape key support & Image size optimization

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -8,5 +8,6 @@
 <!-- attribution appreciated. github: zjeaton web: https://froglegs.co -->
 
 <div class="md__image">
-  <img id="{{ first 6 (shuffle (seq 1 500)) }}" src="{{ .Destination | safeURL }}" onclick="openModal(this.id)" alt="{{ .Text }}" {{ with .Title}} class="{{ . }}" {{ end }} />
+  <img id="{{ first 6 (shuffle (seq 1 500)) }}" src="{{ .Destination | safeURL }}" onclick="openModal(this.id)" alt="{{ .Text }}" {{ with .Title}} class="{{ . }}" {{ end }} 
+  style="max-width: 70%; max-height: 80vh; height: auto; display: block; margin: 0 auto; object-fit: contain;" />
 </div>

--- a/layouts/partials/image-modal.html
+++ b/layouts/partials/image-modal.html
@@ -34,6 +34,13 @@ function closeModal() {
   document.getElementById("myModal").style.display = "none";
 }
 
+// Listen for the Escape key to close the modal
+document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape") {
+        closeModal();
+    }
+});
+
 </script>
 
 <!-- To attach onclick attribute to all <img> -->


### PR DESCRIPTION
**Description**
This PR introduces two improvements to the documentation:
1. **Lightbox Enhancement**: Adds support for closing the modal when the `Escape` key is pressed.
2. **Image Display Optimization**: Ensures that both Markdown images and `<img>` elements are properly scaled to avoid overly large displays by default.

This improves user experience by preventing images from taking up excessive space and making the Lightbox more user-friendly.

**Notes for Reviewers**
- My local environment displays images correctly, but the official site shows different images, even though the paths are identical.  
- Could this be a CDN caching issue, or is there another caching layer affecting images?  
- Does the site apply any automatic image processing that might alter them?  

Any insights would be greatly appreciated. Thank you! 😊  

- [x] Yes, I signed my commits.

<img width="1005" alt="1741740998865" src="https://github.com/user-attachments/assets/e3e4a715-e2f5-4cdc-b3e7-93e66709733a" />
<img width="1021" alt="1741741030580" src="https://github.com/user-attachments/assets/8bafcefb-0938-4b41-ab2b-dd7b34ed72e2" />
