### PR TITLE
fix: correct default title behavior in alert component when only color is provided

### DIFF
--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -55,13 +55,29 @@
 
 {{ $_hugo_config := `{ "version": 1 }` }}
 {{ $color := .Get "color" | default "primary" }}
-<div class="alert alert-{{ $color }}" role="alert">
-{{ with .Get "title" | default "Success"}}<h4 class="alert-heading">{{ . | safeHTML }}</h4>{{ end }}
-{{ if eq .Page.File.Ext "md" }}
-    {{ .Inner | markdownify }}
-{{ else }}
-    {{ .Inner | htmlUnescape | safeHTML }}
+{{ $title := .Get "title" }}
+
+{{ if not $title }}
+  {{ if eq $color "warning" }}
+    {{ $title = "Warning" }}
+  {{ else if eq $color "danger" }}
+    {{ $title = "Danger" }}
+  {{ else if eq $color "info" }}
+    {{ $title = "Info" }}
+  {{ else if eq $color "note" }}
+    {{ $title = "Note" }}
+  {{ else }}
+    {{ $title = "Success" }}
+  {{ end }}
 {{ end }}
+
+<div class="alert alert-{{ $color }}" role="alert">
+  <h4 class="alert-heading">{{ $title | safeHTML }}</h4>
+  {{ if eq .Page.File.Ext "md" }}
+      {{ .Inner | markdownify }}
+  {{ else }}
+      {{ .Inner | htmlUnescape | safeHTML }}
+  {{ end }}
 </div>
 
 {{ end }}


### PR DESCRIPTION

### Problem

The `alert` shortcode currently uses the `type` parameter to determine the styling and default title (e.g., "Danger", "Warning", "Info", "Note"). However, many usages of the `alert` shortcode in the documentation only specify the `color` parameter without setting the `type` parameter.

### Cause

- The current implementation does not dynamically adjust the title based on the `color` parameter.
- It assumes that either `type` is provided, or if not, defaults to "Success" without checking the `color`.

### Solution

In the fallback branch (when no recognized `type` is provided), I added logic to dynamically set a default title based on the `color` parameter if no explicit `title` is provided. The updated logic behaves as follows:

- [x] Yes, I signed my commits.
