### PR TITLE
[docs] Improve lightbox behavior: allow closing by clicking anywhere

### DIFF
--- a/layouts/partials/image-modal.html
+++ b/layouts/partials/image-modal.html
@@ -1,4 +1,3 @@
-
 <div id="myModal" class="modal">
   <button class="modal-close" onclick="closeModal()">close</button>
   <div class="modal-cont">
@@ -27,7 +26,6 @@ function openModal(imageIdOrElement) {
   document.getElementById("myModal").style.display = "block";
 }
 
-
 // Close the Modal
 function closeModal() { 
   document.getElementById("modalPic").src = "";
@@ -36,23 +34,26 @@ function closeModal() {
 
 // Listen for the Escape key to close the modal
 document.addEventListener("keydown", function (event) {
-    if (event.key === "Escape") {
-        closeModal();
-    }
+  if (event.key === "Escape") {
+    closeModal();
+  }
 });
 
-</script>
-
-<!-- To attach onclick attribute to all <img> -->
-<script>
-  document.addEventListener("DOMContentLoaded", function () {
-    var imgTags = document.querySelectorAll("img");
-    imgTags.forEach(function (img) {
-      img.onclick = function () {
-        if (img.dataset.modal !== "false") {
-                openModal(img);
-            }
-      };
-    });
+// Attach onclick attribute to all <img> after DOM is loaded
+document.addEventListener("DOMContentLoaded", function () {
+  var imgTags = document.querySelectorAll("img");
+  imgTags.forEach(function (img) {
+    img.onclick = function () {
+      if (img.dataset.modal !== "false") {
+        openModal(img);
+      }
+    };
   });
-  </script>
+
+  // New: Close modal when clicking anywhere inside #myModal
+  var modal = document.getElementById("myModal");
+  modal.addEventListener("click", function () {
+    closeModal();
+  });
+});
+</script>

--- a/layouts/partials/image-modal.html
+++ b/layouts/partials/image-modal.html
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", function () {
     };
   });
 
-  // New: Close modal when clicking anywhere inside #myModal
+  // Close modal when clicking anywhere inside #myModal
   var modal = document.getElementById("myModal");
   modal.addEventListener("click", function () {
     closeModal();


### PR DESCRIPTION
This pull request improves the behavior of the lightbox modal used for image enlargements.

Previously, users could only close the modal by clicking the "close" button or pressing the Escape key.  
With this change, users can now close the lightbox by clicking anywhere on the modal overlay, including both the background area and the image itself. This improvement makes the interaction more intuitive and user-friendly.

### Changes
Added an event listener to the `#myModal` element to close the modal when clicking anywhere inside it.

### Signed commits

- [x] Yes, I signed my commits.
