### PR TITLE
Fix: Enforce consistent, responsive `<figure>` styling to match markdown image behavior

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -460,7 +460,7 @@ figure,
 figure[style*="width"] {
   width: 100% !important;
   max-width: 70% !important;
-  margin: 0 auto !important;
+  margin: 0 auto 2rem auto !important;
 
   display: flex;
   flex-direction: column;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -458,7 +458,7 @@ a:not([href]):not([class]):hover {
 
 figure,
 figure[style*="width"] {
-  width: 100% !important;
+  width: auto !important;
   max-width: 70% !important;
   margin: 0 auto 2rem auto !important;
 

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -491,6 +491,31 @@ figure[style*="width"] {
   }
 }
 
+// Mobile: override for full-width content alignment
+@media (max-width: 600px) {
+  figure,
+  figure[style*="width"] {
+    max-width: 100% !important;
+    box-sizing: border-box;
+  }
+}
+
+.md__image img,
+img.md-image-responsive {
+  max-width: 70%;
+  max-height: 80vh;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+  object-fit: contain;
+
+  @media (max-width: 600px) {
+    max-width: 100%;
+    padding: 0 1rem;
+    box-sizing: border-box;
+  }
+}
+
 .dashboard {
   font-weight: 800;
   margin-bottom: 4rem;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -456,26 +456,38 @@ a:not([href]):not([class]):hover {
   }
 }
 
-figure {
+figure,
+figure[style*="width"] {
+  width: 100% !important;
+  max-width: 70% !important;
+  margin: 0 auto !important;
+
   display: flex;
   flex-direction: column;
+  align-items: center;
 
-  > img:hover { cursor: pointer; }
   > img {
-    margin: 0 auto; // Center the image
-    margin-bottom: 0px !important;
+    width: 100% !important;
+    height: auto !important;
+    object-fit: contain !important;
+    display: block !important;
+    margin: 0 auto !important;
     border-radius: .5rem .5rem 0rem 0rem !important;
     box-shadow: 0 0 0.5rem rgba(0, 179, 159, 0.4) !important;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
-  figcaption {
-    color: $dark;
-    background-color: rgba($lightslategray, 1);
-    // font-style:italic;
+
+  > figcaption {
+    width: 100% !important;
     text-align: center;
-    margin: 0rem;
-    padding: 0 0.45 0.45 0.45rem;
+    padding: 0.5rem 1rem;
+    background-color: rgba($lightslategray, 1);
+    color: $dark;
     border-radius: 0 0 .5rem .5rem;
-    box-sizing: border-box; // Include padding in width calculation
+    box-sizing: border-box;
   }
 }
 

--- a/content/en/kanvas/advanced/performance/index.md
+++ b/content/en/kanvas/advanced/performance/index.md
@@ -43,7 +43,7 @@ Kanvas supports up to 1,000 relationships per design. Exceeding this limit can i
 
 #### Maximum Number of TagSet Relationships
 
-<img alt="Labels and Annotations" src="../../designer/tagsets/group-components.png" width="15%" />
+![Labels and Annotations](../../designer/tagsets/group-components.png)
 
 Tags are indexed and searchable. However, the performance of design operations may degrade as the number of tags increases. To ensure an optimal user experience, we recommend using tags judiciously and limiting the number of tags used in a design.
 
@@ -71,7 +71,7 @@ Under the Free subscription plan, Kanvas support a single image size of up to 50
 
 To improve the performance of your design, consider optimizing by disabling one or more layers.
 
-<figure style="width:600px;">
+<figure">
   <img src="./layers-panel.png" alt="Layers panel in Kanvas Designer" />
   <figcaption>Control which layers of your design are visible using the Layers panel.</figcaption>
 </figure>

--- a/content/en/kanvas/advanced/performance/index.md
+++ b/content/en/kanvas/advanced/performance/index.md
@@ -71,7 +71,7 @@ Under the Free subscription plan, Kanvas support a single image size of up to 50
 
 To improve the performance of your design, consider optimizing by disabling one or more layers.
 
-<figure">
+<figure>
   <img src="./layers-panel.png" alt="Layers panel in Kanvas Designer" />
   <figcaption>Control which layers of your design are visible using the Layers panel.</figcaption>
 </figure>

--- a/content/en/kanvas/reference/contributing-to-docs.md
+++ b/content/en/kanvas/reference/contributing-to-docs.md
@@ -180,6 +180,17 @@ This default styling works well for most landscape (horizontal) images. However,
 <img src="./images/example.png" alt="Example description" style="max-width: 40vw; max-height: 60vh; display: block; margin: 1rem auto;" />
 ```
 
+If you want your image to include a caption for explanation or accessibility, you can use the `<figure>` element:
+
+```html
+<figure>
+  <img src="./images/example.png" alt="Example description" />
+  <figcaption>Example: Control which layers of your design are visible using the Layers panel.</figcaption>
+</figure>
+```
+
+Using `<figure>` allows you to pair an image with a caption while preserving semantic structure and visual consistency. It's particularly useful for annotated screenshots or UI illustrations.
+
 ### Additional resources
 
 - **Bootstrap image utilities:**  

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -8,6 +8,6 @@
 <!-- attribution appreciated. github: zjeaton web: https://froglegs.co -->
 
 <div class="md__image">
-  <img id="{{ first 6 (shuffle (seq 1 500)) }}" src="{{ .Destination | safeURL }}" onclick="openModal(this.id)" alt="{{ .Text }}" {{ with .Title}} class="{{ . }}" {{ end }} 
-  style="max-width: 70%; max-height: 80vh; height: auto; display: block; margin: 0 auto; object-fit: contain;" />
+  <img id="{{ first 6 (shuffle (seq 1 500)) }}" src="{{ .Destination | safeURL }}" onclick="openModal(this.id)" alt="{{ .Text }}" 
+  class="md-image-responsive{{ with .Title }} {{ . }}{{ end }}" />
 </div>


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #522

- [x] Yes, I signed my commits.

### Problem
The current `<figure>` styling does not adapt well when inline style="width:..." is present. In such cases, the figure can exceed the intended content width and introduce excessive horizontal gaps, especially on smaller screens.

### Resolution
This PR updates the styling of the `<figure>` element in `assets/scss/_styles_project.scss` to:

* Align with the behavior of markdown images rendered via `layouts/_default/_markup/render-image.html`
* Ensure consistent responsiveness by applying:

  * `width: 100%` and `max-width: 70%` to `figure` and `figure[style*="width"]`
  * `width: 100%` to nested `<img>` and `<figcaption>`
  * `object-fit: contain`, `display: block`, and centered alignment
* Override any inline width declarations (e.g., `style="width:600px"`) using `!important`

Although `<figure>` is infrequently used (standard markdown image syntax is more common), it remains useful for including captions or grouped content. To support this usage, this PR also updates **contributing-to-docs** with usage guidance and examples.

![image](https://github.com/user-attachments/assets/363e7fdd-a9e2-461a-913d-041c3b7f9031)

