### PR TITLE
Fix image scaling and align figcaption width to image

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -458,7 +458,7 @@ a:not([href]):not([class]):hover {
 
 figure,
 figure[style*="width"] {
-  width: auto !important;
+  width: max-content !important;
   max-width: 70% !important;
   margin: 0 auto 2rem auto !important;
 
@@ -467,7 +467,8 @@ figure[style*="width"] {
   align-items: center;
 
   > img {
-    width: 100% !important;
+    width: auto !important;
+    max-width: 100% !important;
     height: auto !important;
     object-fit: contain !important;
     display: block !important;
@@ -502,6 +503,7 @@ figure[style*="width"] {
 
 .md__image img,
 img.md-image-responsive {
+  width: auto;
   max-width: 70%;
   max-height: 80vh;
   height: auto;
@@ -510,6 +512,7 @@ img.md-image-responsive {
   object-fit: contain;
 
   @media (max-width: 600px) {
+    width: auto;
     max-width: 100%;
     padding: 0 1rem;
     box-sizing: border-box;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -460,7 +460,7 @@ figure,
 figure[style*="width"] {
   width: max-content !important;
   max-width: 70% !important;
-  margin: 0 auto 2rem auto !important;
+  margin: 0 auto 2rem auto;
 
   display: flex;
   flex-direction: column;
@@ -469,10 +469,10 @@ figure[style*="width"] {
   > img {
     width: auto !important;
     max-width: 100% !important;
-    height: auto !important;
+    height: auto;
     object-fit: contain !important;
-    display: block !important;
-    margin: 0 auto !important;
+    display: block;
+    margin: 0 auto;
     border-radius: .5rem .5rem 0rem 0rem !important;
     box-shadow: 0 0 0.5rem rgba(0, 179, 159, 0.4) !important;
 


### PR DESCRIPTION
This PR improves the rendering of images and captions within `figure` elements. It ensures that images retain their original dimensions and are no longer stretched beyond their natural size. 

1. By setting `figure` to `max-content` and applying `width: auto` with `max-width` constraints on images, captions now consistently align with the visual width of images.
2. Unnecessary `!important` declarations were removed for cleaner and more maintainable styles.

