### PR TITLE
support non-bootstrap local icons

### DIFF
--- a/layouts/partials/video-landing-page.html
+++ b/layouts/partials/video-landing-page.html
@@ -10,7 +10,11 @@
         <a href="#category-{{ $index }}" class="category-tab" data-category="{{ $index }}">
           <div class="tab-icon">
             {{ if .Params.icon }}
-              <i class="bi {{ .Params.icon }}"></i>
+              {{ if hasPrefix .Params.icon "bi" }}
+                <i class="bi {{ .Params.icon }}"></i>
+              {{ else }}
+                 <img src="{{ .Params.icon }}" alt="{{ .Title }} icon" style="max-width: 100%;object-fit: contain;"/>
+              {{ end }}
             {{ else }}
               <i class="bi bi-collection-play"></i>
             {{ end }}


### PR DESCRIPTION
**Notes for Reviewers**

doing `icon: /images/grid-icon.svg` in `content/en/videos/integrations/_index.md` results in: 
![image](https://github.com/user-attachments/assets/f89419e5-b106-498f-bcd7-971f9c86f7a4)





**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
