### PR TITLE
revert back resources dropdown-menu to column direction

### DIFF
--- a/assets/scss/_navbar_project.scss
+++ b/assets/scss/_navbar_project.scss
@@ -35,6 +35,10 @@
       content: "";
       width: 5rem;
     }
+    &--col{
+      flex-direction: column;
+      padding: 0.1rem .1rem;
+    }
     .dropdown-item {
       height: 5rem;
       width: 5rem;
@@ -60,6 +64,15 @@
         color: $black;
         img {
           filter: brightness(0) invert(1);
+        }
+      }
+      &--row{
+        flex-direction: row;
+        height: 3rem;
+        width: auto;
+        margin: 0.1rem 0rem;
+        .logo-container {
+          margin-right: 1rem;
         }
       }
     }

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -36,9 +36,9 @@
                         >
                         Resources<span class="down-icon">&#9660;</span>
                         </div>
-                        <div class="dropdown-menu" aria-labelledby="resourcesDropdown" style="visibility:hidden;">
+                        <div class="dropdown-menu dropdown-menu--col" aria-labelledby="resourcesDropdown" style="visibility:hidden;">
                           <a
-                          class="dropdown-item"
+                          class="dropdown-item dropdown-item--row"
                           href="https://cloud.layer5.io/academy/overview"
                           target="_blank"
                           >
@@ -52,7 +52,7 @@
                           </a>
                           <div class="dropdown-divider"></div>
                           <a
-                          class="dropdown-item"
+                          class="dropdown-item dropdown-item--row"
                           href="https://docs.layer5.io/videos"
                           target="_blank"
                           >


### PR DESCRIPTION
**Notes for Reviewers**
I have reverted back to original proposed column direction for dropdown-menu.
<img width="217" alt="image" src="https://github.com/user-attachments/assets/54531838-47ca-4f75-90e7-4e66b6c4b8e6" />

This PR fixes #
add resources dropdown in nav menu [#518 ](https://github.com/layer5io/docs/issues/518)



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
