### PR TITLE
Fix: Set Transparent Background for Kanvas Logo (#588)

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -721,3 +721,9 @@ a:not([href]):not([class]):hover {
 .csvtable {
   width: 100%;
 }
+
+.img-thumbnail,
+.td-content img {
+  background-color: transparent;
+}
+


### PR DESCRIPTION
This PR resolves Issue #588 by ensuring the Kanvas logo has a transparent background, rather than displaying with an unintended black background.

🔧 What’s Changed
Added a CSS rule to _styles_project.scss to apply background-color: transparent to image elements like .img-thumbnail and .td-content img.

This ensures all SVGs and other images render with proper transparent backgrounds across the site.

**Notes for Reviewers**

This PR fixes #588 

Before : 
https://i.postimg.cc/h43YHBWW/449377089-28df93af-a82b-41c8-875f-99f1488d1fcf.png

After : 
https://i.postimg.cc/mkcmbPfx/Screenshot-213.png






**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
