### PR TITLE
Fix: Zoom in and out shortcut keys

### DIFF
--- a/content/en/kanvas/reference/keyboard-shortcuts.md
+++ b/content/en/kanvas/reference/keyboard-shortcuts.md
@@ -24,6 +24,10 @@ As a designer in Kanvas, you can take advantage of various keyboard shortcuts to
 - <button class="kbc-button kbc-button-xs">Ctrl</button> + <button class="kbc-button kbc-button-xs">Y</button> or <button class="kbc-button kbc-button-xs">Shift</button> + <button class="kbc-button kbc-button-xs">Z</button>: Redo your last create or delete action.
 - <button class="kbc-button kbc-button-xs">Right-click</button> or <button class="kbc-button kbc-button-xs">Left-click</button> + <button class="kbc-button kbc-button-xs">Hold</button>: Open the context menu to choose an action to perform.
 - <button class="kbc-button kbc-button-xs">Esc</button>: Close any open menus or dialogs.
+- <button class="kbc-button kbc-button-xs">Ctrl</button> + <button class="kbc-button kbc-button-xs">+</button>: Zoom in on the canvas.
+- <button class="kbc-button kbc-button-xs">Ctrl</button> + <button class="kbc-button kbc-button-xs">-</button>: Zoom out on the canvas.
+- <button class="kbc-button kbc-button-xs">Ctrl</button> + <button class="kbc-button kbc-button-xs">Shift</button> + <button class="kbc-button kbc-button-xs">+</button>: Zoom in on the Page.
+- <button class="kbc-button kbc-button-xs">Ctrl</button> + <button class="kbc-button kbc-button-xs">Shift</button> + <button class="kbc-button kbc-button-xs">-</button>: Zoom out on the Page.
 
 These designer shortcuts are essential for a smooth and efficient design workflow within Kanvas.
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR adds keyboard shortcuts for zooming in and out of the canvas and the page.

![image](https://github.com/user-attachments/assets/007be9d8-79ca-490f-a949-f818b62ad649)

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
