### PR TITLE
Implemented Heading Permalinks with Hover/Visible Chain Icon #596

### DIFF
--- a/assets/scss/_elements_project.scss
+++ b/assets/scss/_elements_project.scss
@@ -153,7 +153,7 @@ div.tip {
 
 .heading-link {
   position: relative;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.3rem;
 

--- a/assets/scss/_elements_project.scss
+++ b/assets/scss/_elements_project.scss
@@ -150,3 +150,25 @@ div.tip {
   font-weight: 600;
   word-break: break-word;
 }
+
+.heading-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+
+  .heading-anchor {
+    font-size: 0.6em;
+    opacity: 0;
+    transform: translateY(2px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    margin-left: 0.25rem;
+    text-decoration: none;
+  }
+
+  &:hover .heading-anchor {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -11,6 +11,7 @@
 @import "_videos_project.scss";
 @import "subscription.scss";
 @import "_video-landing_project.scss";
+@import "elements_project";
 
 .navbar-dark {
   min-height: 5rem;

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -2,9 +2,8 @@
 {{- $text := .Text | safeHTML -}}
 {{- $anchor := .Anchor | safeURL -}}
 
-<h{{ $level }} id="{{ $anchor }}" class="heading-link">
-  {{ $text }}
-  <a class="heading-anchor" href="#{{ $anchor }}" aria-label="Anchor link to this section">
-    🔗
-  </a>
+{{ $level := .Level }}
+<h{{ $level }} id="{{ .Anchor | safeURL }}" class="heading-link">
+  {{ .Text }}
+  <a href="#{{ .Anchor | safeURL }}" class="heading-anchor" aria-label="Permalink to this heading">🔗</a>
 </h{{ $level }}>

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,10 @@
+{{- $level := .Level -}}
+{{- $text := .Text | safeHTML -}}
+{{- $anchor := .Anchor | safeURL -}}
+
+<h{{ $level }} id="{{ $anchor }}" class="heading-link">
+  {{ $text }}
+  <a class="heading-anchor" href="#{{ $anchor }}" aria-label="Anchor link to this section">
+    🔗
+  </a>
+</h{{ $level }}>


### PR DESCRIPTION
**Notes for Reviewers**

Implemented heading permalinks across all Markdown heading levels using Hugo’s render-heading.html hook. Added a chain icon (🔗) that appears on hover for easy linking, with smooth transitions and consistent sizing for better UX.

This PR fixes #596 




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
