### PR TITLE
Fix: Remove redundant heading anchors on Environments page

### DIFF
--- a/content/en/cloud/spaces/environments.md
+++ b/content/en/cloud/spaces/environments.md
@@ -31,14 +31,14 @@ Environments represent a collection of resources in the form of Connections - bo
 
 ## Key Components
 
-### Connections <a id="connections"></a>
+### Connections
 
 Connections are an integral part of Environment. These are cloud native resources that can be both managed and unmanaged, and they're registered by the Meshery Server. Examples of connections include Kubernetes clusters, Prometheus instances, Jaeger tracers, and Nginx web servers.
 
-See "[Connections](https://docs.meshery.io/concepts/logical/connections)" in Meshery Docs for more information.
+> See "[Connections](https://docs.meshery.io/concepts/logical/connections)" in Meshery Docs for more information.
 
-### Credentials <a id="credentials"></a>
+### Credentials
 
 Credentials in an Environment are the keys to securely authenticate and access managed connections. For example, valid Prometheus secrets or Kubernetes API tokens are essential credentials for securely interacting with these managed resources.
 
-See "[Credentials](https://docs.meshery.io/concepts/logical/credentials)" in Meshery Docs for more information.
+> See "[Credentials](https://docs.meshery.io/concepts/logical/credentials)" in Meshery Docs for more information.


### PR DESCRIPTION
**Notes for Reviewers**

This pull request removes manual anchor tags (`<a id="...">`) from the "Connections" and "Credentials" subheadings on the Environments documentation page.
These explicit anchors are now redundant, as we automatically generates linkable IDs for all headings.

Before:
![image](https://github.com/user-attachments/assets/80f96914-a4d7-4f32-829b-e702cbe820f2)

After:
![image](https://github.com/user-attachments/assets/e14558f2-8309-4c8a-ab6f-be3f59190952)


