### PR TITLE
[UI] Apply Layer5 brand color to search clear ('x') button – Fixes #544

### DIFF
--- a/assets/scss/_search_project.scss
+++ b/assets/scss/_search_project.scss
@@ -169,3 +169,11 @@
 .form-control {
   border: 1px solid #ced4da;
 }
+input[type="search"]::-webkit-search-cancel-button {
+  filter: invert(55%) sepia(75%) saturate(380%) hue-rotate(135deg) brightness(95%) contrast(90%);
+  cursor: pointer;
+  transform: scale(1.1);
+}
+input[type="search"]::-webkit-search-cancel-button:hover {
+  filter: invert(60%) sepia(95%) saturate(500%) hue-rotate(140deg) brightness(100%) contrast(100%);
+}


### PR DESCRIPTION
Updated the colour of the x button in the search button

**Notes for Reviewers**

This PR fixes #544 
![image](https://github.com/user-attachments/assets/814cb37d-1d9e-410c-a23e-84c2ae7f9be6)
This is the changes that I have made 




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
