### PR TITLE
[Docs] Add tabpane shortcode usage example to contributing guide #504

### DIFF
--- a/content/en/contributing/_index.md
+++ b/content/en/contributing/_index.md
@@ -5,3 +5,18 @@ type: docs
 cascade: 
     type: docs
 ---
+## TabPane Shortcode Example
+
+Layer5 docs support tabbed content using the `tabpane` shortcode. Here’s a basic example:
+
+{{< tabpane >}}
+  {{< tab name="Example Tab 1" >}}
+  This is the content inside Tab 1.
+  {{< /tab >}}
+
+  {{< tab name="Example Tab 2" >}}
+  This is the content inside Tab 2.
+  {{< /tab >}}
+{{< /tabpane >}}
+
+Use this shortcode to display platform-specific commands, language-specific code blocks, or comparisons — all in an elegant, user-friendly tab layout.


### PR DESCRIPTION
Added an example usage of the tabpane shortcode to the Contributing Guide. This helps contributors understand how to implement tabbed content in documentation, which can be useful for organizing related information like platform-specific commands or language-based code examples.

**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
