### PR TITLE
fix: Pin Hugo version for Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,7 @@ publish = "public"
 
 [build.environment]
 GO_VERSION = "1.23.8"
+HUGO_VERSION = "0.148.1"
 
 [context.production]
 command = "npm run build:production"


### PR DESCRIPTION
**Notes for Reviewers**

This PR resolves the ongoing Netlify build failures.

### Problem
The build was failing because the Netlify environment was using an outdated default version of Hugo (`v0.126.2`). This version is incompatible with the latest `docsy` theme and caused errors like `function "try" not defined`.

#### Solution
This change explicitly sets `HUGO_VERSION = "0.148.1"` in the `netlify.toml` file, ensuring that the build environment uses the correct version required by the project. This should resolve the build failures.