### PR TITLE
hide two latest cloud release from sidebar

### DIFF
--- a/content/en/cloud/reference/releases/v0.8.344.md
+++ b/content/en/cloud/reference/releases/v0.8.344.md
@@ -3,6 +3,7 @@ title: v0.8.344
 date: 2025-08-02T00:46:31Z
 tag: v0.8.344
 prerelease: false
+toc_hide: true
 ---
 
 ## What's New
@@ -23,4 +24,5 @@ prerelease: false
 
 Thank you to our contributors for making this release possible:
 @dependabot, @dependabot[bot], @google-labs-jules[bot], @l5io, @leecalcote, @ritzorama and @sangramrath
+
 

--- a/content/en/cloud/reference/releases/v0.8.345.md
+++ b/content/en/cloud/reference/releases/v0.8.345.md
@@ -3,6 +3,7 @@ title: v0.8.345
 date: 2025-08-02T08:50:40Z
 tag: v0.8.345
 prerelease: false
+toc_hide: true
 ---
 
 ## What's New
@@ -19,4 +20,5 @@ prerelease: false
 
 Thank you to our contributors for making this release possible:
 @aabidsofi19 and @l5io
+
 


### PR DESCRIPTION
**Notes for Reviewers**
Maintainer @zihanKuang between the pr's #734  last commit and its merge, two new cloud releases were made and not accounted for, hence these two are visible in https://docs.layer5.io/cloud/reference/releases/.

This PR fixes that.

All future releases now automatically be hidden



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
