### PR TITLE
Improve Summary and Detail Element Styling

### DIFF
--- a/assets/scss/_content_project.scss
+++ b/assets/scss/_content_project.scss
@@ -151,6 +151,7 @@ h6 {
   >ol,
   >p,
   >pre,
+  >details,
   >ul {
     @extend .td-max-width-on-larger-screens;
   }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -12,6 +12,7 @@
 @import "subscription.scss";
 @import "_video-landing_project.scss";
 @import "elements_project";
+@import "summary.scss";
 
 .navbar-dark {
   min-height: 5rem;

--- a/assets/scss/_summary.scss
+++ b/assets/scss/_summary.scss
@@ -1,0 +1,59 @@
+
+details {    
+    width: 100%;
+    margin: 0 ;
+    background-color: lighten($dark, 5%);
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    box-shadow: 0 .1rem 1rem -.5rem rgba($dark, 0.4);
+    border-radius: 5px;
+    overflow: hidden;
+    font-size: 1rem;
+    padding: 0rem 1.5rem 0rem 1.5rem;
+    & > h6 { color: $blonde};
+    & > p { color: $body-color};
+  }
+  
+  summary {
+    padding: .25rem 0rem;
+    margin-right: -1.5rem;
+    margin-left: -1.5rem;  
+    display: block;
+    background-color: lighten($dark, 5%); 
+    color: $navbar-dark-color;
+    padding-left: 2.2rem;
+    position: relative;
+    cursor: pointer;
+    font-size: 1.1rem;
+    font-weight: normal;
+  }
+  
+  summary:before {
+    content: '';
+    border-width: .4rem;
+    border-style: solid;
+    border-color: transparent transparent transparent $body-color;
+    position: absolute;
+    left: 1rem;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    height: .02rem;
+    margin: auto;
+    transform: rotate(0);
+    transform-origin: .2rem 50%;
+    transition: .25s transform ease;
+  }
+  
+  details[open] > summary:before {
+    transform: rotate(90deg);
+  }
+  
+  details summary::-webkit-details-marker {
+    display:none;
+  }
+  
+  details > ul {
+    padding: 1rem auto;
+    margin-bottom: 0;
+  }


### PR DESCRIPTION
**Notes for Reviewers**

This PR addresses the issue where the default styling of `summary` and `detail` elements was very inconspicuous.

I've leveraged the collapsible section CSS from the `Meshery repo`, with adjustments to colors and margins, to enhance the display in the `layer5-docs` repository. Testing confirms that Markdown formatting, centered images, lightboxes, and code blocks all render correctly within the collapsible sections.

Reference Meshery CSS:
https://github.com/meshery/meshery/blob/8e20856a962fdb2fee3f9985ec899da8a56aec16/docs/_sass/helpers.scss#L111


**Before:**
<img width="1476" height="978" alt="image" src="https://github.com/user-attachments/assets/cb583c0e-3fb1-40a3-83e4-603c0a1dbd8c" />

**After:**
<img width="1063" height="408" alt="image" src="https://github.com/user-attachments/assets/b159a06b-0a52-422d-a911-ffca8e96b0a0" />

<img width="1216" height="1000" alt="image" src="https://github.com/user-attachments/assets/6d9e5124-7521-43cf-8869-6ccabdc3173c" />


