### PR TITLE
Fix: Update FAQ on video asset size limitation and remove head(link of Academy) section

### DIFF
--- a/content/en/cloud/academy/creating-content/creating-your-learning-path/index.md
+++ b/content/en/cloud/academy/creating-content/creating-your-learning-path/index.md
@@ -365,39 +365,49 @@ make clean
 
 ## Frequently Asked Questions
 
-1. **Why is my workflow failing with a `401 Unauthorized` or `user must be logged in` error?**
+<details>
+  <summary>1. Why is my workflow failing with a <code>401 Unauthorized</code> or <code>User must be logged in</code> error?</summary>
+  
+This error indicates an issue with your <code>ACADEMY_TOKEN</code>. Please ensure you have correctly copied only the token string and not the entire JSON object from the downloaded file.
+</details>
 
-    This error indicates an issue with your **`ACADEMY_TOKEN`**. Please ensure you have correctly copied **only the token string** and not the entire JSON object from the downloaded file.
+<details>
+  <summary>2. Why is my workflow failing with a URL containing a double slash </code>( // )</code>?</summary>
+  
+A double slash in the URL (e.g., <code>.../api/academy//update/...</code>) means your <strong>ACADEMY_ORG_ID</strong> was not found. This typically happens when the secret name in your repository does not <strong>exactly match</strong> the name expected by the workflow file (e.g., <code>ORG_ID</code>).
+</details>
 
-2. **Why is my workflow failing with a URL containing a double slash (`//`)?**
+<details>
+  <summary>3. How do I handle updates or corrections after my content is live?</summary>
+  
+All content updates are managed through your Git repository. Simply commit and push your changes, then <strong>create a new GitHub Release</strong> with a new version number (e.g., <code>v1.0.2</code>). This automatically triggers the publishing workflow and updates your content on the Academy platform.
+</details>
 
-    A double slash in the URL (e.g., `.../api/academy//update/...`) means your **`ACADEMY_ORG_ID`** was not found. This typically happens when the secret name in your repository does not **exactly match** the name expected by the workflow file (e.g., `ORG_ID`).
+<details>
+  <summary>4. What happens if my new content has an error?</summary>
+  
+The publishing process is designed to be safe. If your new content causes a build error, the workflow will fail, and the previously working version of the Academy will remain unchanged. Your broken update will not be published.
+</details>
 
-3. **How do I handle updates or corrections after my content is live?**
+<details>
+  <summary>5. How do I structure multiple courses under one learning path?</summary>
+  
+The structure is defined by your folder hierarchy. A learning path is a directory, and each course is a sub-directory within that path. This folder structure in your <code>content</code> directory directly maps to the learning path structure presented to users.
+</details>
 
-    All content updates are managed through your Git repository. Simply commit and push your changes, then **create a new GitHub Release** with a new version number (e.g., `v1.0.2`). This automatically triggers the publishing workflow and updates your content on the Academy platform.
-
-4. **What happens if my new content has an error?**
-
-    The publishing process is designed to be safe. If your new content causes a build error, the workflow will fail, and the previously working version of the Academy will remain unchanged. Your broken update will not be published.
-
-5. **How do I structure multiple courses under one learning path?**
-
-    The structure is defined by your folder hierarchy. A learning path is a directory, and each course is a sub-directory within that path. This folder structure in your `content` directory directly maps to the learning path structure presented to users.
-
-6. **Why does my local build fail when adding large videos?**
-
-    Hugo's default memory limit is 512MB. For videos >50MB:
-    ```bash
-    hugo server --memlimit 2GB
-    ```
-
-7.  **How to securely host private training videos?**
-
-    Use AWS S3 with signed URLs:
-    ```html
-    <video src="{{</* s3_signed_url path="training/private.mp4" */>}}">
-    ```
-
+<details>
+  <summary>6. Why does my local build fail when adding large videos?</summary>
+  
+The ideal size should be less than 10MB for our service performance and sustainability, and server resource management. If your asset size is larger than 10MB, we recommend using external hosting as listed.
+</details>
+ 
+<details>
+  <summary>7. How to securely host private training videos?</summary>
+  
+Use AWS S3 with signed URLs:
+```html
+<video src="{{</* s3_signed_url path="training/private.mp4" */>}}">
+```
+</details>
 
 [^1]: The auto-generated learning path ID feature will be launched soon.            

--- a/content/en/cloud/academy/creating-content/integrating-assessments-in-the-academy/index.md
+++ b/content/en/cloud/academy/creating-content/integrating-assessments-in-the-academy/index.md
@@ -305,42 +305,33 @@ After an assessment is submitted and scored, a detailed result record is permane
 
 ## Frequently Asked Questions
 
-<details style="margin-bottom: 1em;">
+<details>
   <summary>1. Is the <code>id</code> field required in the file's front matter?</summary>
 
-  <div style="padding-left: 1.5em;">
-    <p><strong>Answer:</strong> No, the <code>id</code> field is <strong>optional</strong>. If omitted, the system auto-generates a unique ID based on the file path (e.g., <code>7a4af2222daae1111acfac539f657724</code>). However, we strongly recommend specifying a human-readable, globally unique ID (e.g., <code>test-intro-meshery</code>, <code>quiz-containers</code>, <code>test-intro-kubernetes</code>) for better traceability and debugging.</p>
-  </div>
+No, the <code>id</code> field is <strong>optional</strong>. If omitted, the system auto-generates a unique ID based on the file path (e.g., <code>7a4af2222daae1111acfac539f657724</code>). However, we strongly recommend specifying a human-readable, globally unique ID (e.g., <code>test-intro-meshery</code>, <code>quiz-containers</code>, <code>test-intro-kubernetes</code>) for better traceability and debugging.
 </details>
 
-<details style="margin-bottom: 1em;">
+<details>
   <summary>2. Why is an assessment required for every Course and Learning Path?</summary>
 
-  <div style="padding-left: 1.5em;">
-    <p><strong>Answer:</strong> The system determines the completion of a Course or Learning Path based on whether the learner passes its designated assessment (e.g., <code>test.md</code>, <code>exam.md</code>). Without this, the system has no trigger to mark the level as completed or to award achievements such as badges. Module-level quizzes are intended for practice and do not trigger parent-level completion.</p>
-  </div>
+The system determines the completion of a Course or Learning Path based on whether the learner passes its designated assessment (e.g., <code>test.md</code>, <code>exam.md</code>). Without this, the system has no trigger to mark the level as completed or to award achievements such as badges. Module-level quizzes are intended for practice and do not trigger parent-level completion.
+
 </details>
 
-<details style="margin-bottom: 1em;">
+<details>
   <summary>3. Can I fully test the assessment (including scoring) locally?</summary>
 
-  <div style="padding-left: 1.5em;">
-    <p><strong>Answer:</strong> You can preview the test layout locally, but scoring and evaluation are handled by the backend server. This means submission, grading, and result processing are not available in local previews. You must publish the content to test full functionality.</p>
-  </div>
+You can preview the test layout locally, but scoring and evaluation are handled by the backend server. This means submission, grading, and result processing are not available in local previews. You must publish the content to test full functionality.
 </details>
 
-<details style="margin-bottom: 1em;">
+<details>
   <summary>4. How are multiple-answer questions scored? Is partial credit given?</summary>
 
-  <div style="padding-left: 1.5em;">
-    <p><strong>Answer:</strong> No partial credit is awarded. To receive points, the learner must select all correct options and avoid all incorrect ones. Selecting a wrong option or missing a correct one results in zero marks for that question.</p>
-  </div>
+No partial credit is awarded. To receive points, the learner must select all correct options and avoid all incorrect ones. Selecting a wrong option or missing a correct one results in zero marks for that question.
 </details>
 
-<details style="margin-bottom: 1em;">
+<details>
   <summary>5. Can a learner retake an assessment even after scoring 100%?</summary>
 
-  <div style="padding-left: 1.5em;">
-    <p><strong>Answer:</strong> Yes. Even if a learner scores 100%, they are allowed to retake the assessment. The system does not restrict retakes based on previous scores. This design supports repeated practice, randomized question pools, and flexible testing workflows—without enforcing score-based access rules.</p>
-  </div>
+Yes. Even if a learner scores 100%, they are allowed to retake the assessment. The system does not restrict retakes based on previous scores. This design supports repeated practice, randomized question pools, and flexible testing workflows—without enforcing score-based access rules.
 </details>


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #756 

1. Remove the head Section. 
2. "Create Your Learning Path FAQ" No.6 Update :with 10MB size restrictions
    The answer is "The ideal size should be less than 10MB for our service performance and sustainability, and server resource management. If your asset size is larger than 10MB, we recommend using external hosting as listed."

3. Make "Create Your Learning Path FAQ" Section Collapsible: converted the FAQ section to a toggle format
4. FAQ Consistency Update: Removed "answer" text from "Integrating Assessments in the Academy" FAQ title

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
6. Build and test your changes before submitting a PR. 
7. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
