### PR TITLE
Fix: Broken Images on Navigating Operator Page

### DIFF
--- a/content/en/kanvas/operator/_index.md
+++ b/content/en/kanvas/operator/_index.md
@@ -20,8 +20,6 @@ Using the search bar, you can search for specific resources and select them. The
 
 <!-- {{< figure src="images/operator-filters.png" link="images/operator-filters.png"  width="100%"  >}} -->
 
-![operator-filters](images/operator-filters.png)
-
 ## Connecting with Kubernetes Pods
 
 Operator supports connecting to Kubernetes pods via the following methods.


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #766 

<img width="1155" height="627" alt="image" src="https://github.com/user-attachments/assets/29ceb757-eddd-4944-8070-b8f09e0aecf6" />

<img width="1168" height="654" alt="image" src="https://github.com/user-attachments/assets/862fe2ad-8f6c-4667-9ca4-8adcaaa24e8b" />





**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
