### PR TITLE
add open design link to embed design shortcode

### DIFF
--- a/layouts/shortcodes/meshery-design-embed.html
+++ b/layouts/shortcodes/meshery-design-embed.html
@@ -28,12 +28,22 @@
 -->
 {{ $id := .Get "id" }}
 
+<!-- get the design id from the id  , the id contains embedded-design- as prefix  -->
+{{ $designId := replace $id "embedded-design-" "" }}
+
+
+<!-- get the hostname for provider -->
+{{ $remoteProviderHost := .Get "host" | default "https://cloud.layer5.io" }}
+<!-- create design link -->
+{{ $designLink := printf "%s/catalog/content/design/%s" $remoteProviderHost $designId }}
+
 <!-- 
   Retrieve the size for the embedding container.
   If not provided, "full" is used as default.
 -->
 {{ $size := .Get "size" | default "full" }}
 {{ $style := .Get "style" }}
+{{ $showOpenLink := .Get "showOpenLink" | default "true" }}
 
 <style>
 .meshery-embed-container {
@@ -54,6 +64,7 @@
   width: 100%;
   height: 100%;
 }
+
 </style>
 
 <!-- 
@@ -66,6 +77,7 @@
       - Width: 100% (responsive to container width)
       - Border: 1px solid #eee (light border for visibility)
 -->
+<div style="display: flex; flex-direction: column; align-items: center; gap: 0.5rem;">
 <div
     id="{{ $id }}"
     {{- if $style -}}
@@ -74,6 +86,12 @@
         class="meshery-embed-container {{ $size }}"
     {{- end -}}
 ></div>
+
+<a href="{{ $designLink }}" target="_blank" rel="noopener noreferrer">
+  Open Design
+</a>
+
+</div>
 
 <!-- 
   Embed Script: 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

Adds support for opening an embedded design’s source on a remote provider.

Introduces a new hostname prop to specify the remote provider’s hostname (defaults to cloud.layer5.io).

Adds a showOpenLink prop to toggle the “Open Design” option (defaults to true).

No additional configuration is required from users — by default, an “Open Design” link will automatically point to the source hosted on the remote provider.

<img width="2" height="1" alt="image" src="https://github.com/user-attachments/assets/587551e5-91aa-4f9c-9665-bcac563e8373" />


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
