### PR TITLE
Add badge metadata to Certification and Learning Path content

### DIFF
--- a/content/en/cloud/academy/creating-content/building-certifications/index.md
+++ b/content/en/cloud/academy/creating-content/building-certifications/index.md
@@ -93,6 +93,11 @@ weight: 1
 tags: [layer5, cloud, infrastructure]
 level: "beginner"
 categories: "platform"
+badge: 
+    png: "https://images.credly.com/images/f28f1d88-428a-47f6-95b5-7da1dd6c1000/twitter_thumb_201604_KCNA_badge.png"
+    svg: "https://images.credly.com/images/f28f1d88-428a-47f6-95b5-7da1dd6c1000/twitter_thumb_201604_KCNA_badge.png"
+    title: "Layer5 Certified"
+    description: "Earn the Certification badge to showcase your expertise in Layer5 cloud services."
 ---
 ```
 
@@ -107,10 +112,11 @@ categories: "platform"
 | `title` | ✅  | The human-readable title that will be displayed to users. |
 | `description` | ✅  | A comprehensive summary of the certification's scope and objectives. |
 | `weight` | - | Controls the display order (lower numbers appear first). Items are sorted alphabetically by title if not specified.|
-| `banner` | - | Path to an image in the `static` folder, e.g., `images/icon.svg`. |
+| `banner` | - | Path to a banner image located in the same folder (Page Bundle).  |
 | `tags` | - | Keywords for content discovery. Multiple tags can be selected. |
 | `level` | - | A string for the intended difficulty (`beginner`, `intermediate`, `advanced`). Default: `beginner`. |
 | `categories` | - | A string that assigns the certification to a specific category. |
+| `badge` | - | Defines the awarded digital badge. The png and svg fields accept either a full remote URL or a local file path for an image in the same folder (e.g., layer5-badge.svg).|
 
 ### 3. Add Content and Exams
 

--- a/content/en/cloud/academy/creating-content/creating-your-learning-path/index.md
+++ b/content/en/cloud/academy/creating-content/creating-your-learning-path/index.md
@@ -145,6 +145,11 @@ Now, inside your academy repository, you should see the following top-level fold
  tags: [kubernetes, infrastructure]
  categories: "cloud"
  level: "beginner"
+ badge: 
+    png: "https://images.credly.com/images/f28f1d88-428a-47f6-95b5-7da1dd6c1000/twitter_thumb_201604_KCNA_badge.png"
+    svg: "https://images.credly.com/images/f28f1d88-428a-47f6-95b5-7da1dd6c1000/twitter_thumb_201604_KCNA_badge.png"
+    title: "Layer5 Certified"
+    description: "Earn the Certification badge to showcase your expertise in Layer5 cloud services."
  ---
  ```
 
@@ -176,11 +181,13 @@ Now, inside your academy repository, you should see the following top-level fold
  | All                           | `weight`      |    -    | Controls the display order (lower numbers appear first). Items are sorted alphabetically by title if not specified.|
  | All                           | `draft`       |    -    | If `true`, the page will not be published.                                                                    |
  | All                           | `type`        |    ✅     | Defines the content's role. Optional values: `challenge`, `learning-path`, `certification`, `course`, `module`, `page`, `test`, or `lab`. |
- | **Learning Path**, **Course** | `level`       |    -    | A string for the intended difficulty (`beginner`, `intermediate`, `advanced`). Default: `beginner`. |
  | **Learning Path** | `id`          |    ✅     | **Crucial.** A stable UUID for tracking progress. **Do not change.**                                    |
+ | **Learning Path** | `badge` | - | Defines the awarded digital badge. The png and svg fields accept either a full remote URL or a local file path for an image in the same folder (e.g., layer5-badge.svg).|
+ | **Learning Path**, **Course** | `level`       |    -    | A string for the intended difficulty (`beginner`, `intermediate`, `advanced`). Default: `beginner`. |
+ | **Learning Path**, **Course** | `banner`      |    -    | Path to a banner image located in the same folder (Page Bundle). |
  | **Learning Path**, **Course**, **module** | `tags`        |    -    | Keywords for content discovery. Multiple tags can be selected.                                                |
  | **Learning Path**, **Course**, **module** | `categories`  |    -    | The main categories for the content. Only one can be selected.                                                |
- | **Learning Path**, **Course** | `banner`      |    -    | Path to a banner image located in the same folder (Page Bundle). |
+
 
 > For a complete list of all predefined variables and advanced usage, please refer to the official [Hugo Front Matter documentation](https://gohugo.io/content-management/front-matter/).
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #749

This PR adds the `badge` field to the front matter for the certification and learning path creation guides.
