### PR TITLE
Fix(ui):Fixed the docs whatever opened componenent section to be high…

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -81,6 +81,7 @@
   
       &.active {
         font-weight: $font-weight-bold;
+        color: $secondary;
       }
     }
   

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -64,7 +64,12 @@
 {{ end -}}
 */ -}}
 
-
+<script>
+document.addEventListener('DOMContentLoaded',()=>{const n=s=>(s||'').replace(/\/+$/,''); const cur=n(location.pathname); let b=null,l=-1;
+document.querySelectorAll('.td-sidebar-nav a[href]').forEach(a=>{const p=n(new URL(a.getAttribute('href'),location).pathname); if(p&&(cur===p||cur.startsWith(p+'/'))&&p.length>l){b=a;l=p.length}});
+if(!b)return; b.classList.add('active');
+for(let e=b.parentElement;e&&!e.classList.contains('td-sidebar-nav');e=e.parentElement){ if(e.tagName==='LI'){const pa=e.querySelector(':scope > a'); if(pa)pa.classList.add('active'); const ul=e.querySelector(':scope > ul'); if(ul)ul.classList.add('show')}}});
+</script>
 
 {{ define "algolia/head" -}}
 


### PR DESCRIPTION
…lighted

**Notes for Reviewers**

This PR fixes #
<img width="1046" height="670" alt="image" src="https://github.com/user-attachments/assets/1fd63aaf-5981-48cb-beee-1e8bafeabfc7" />
For all the sections on the left sidebar, under operator, if that section is opened it would not show that it is highlighted.

A break in pattern is seen.
<img width="1265" height="774" alt="image" src="https://github.com/user-attachments/assets/8f89168d-7fc2-48ca-82f3-0427970e4e4c" />




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
