### PR TITLE
[UI] White labeling page active tab text color fix

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -744,6 +744,7 @@ a:not([href]):not([class]):hover {
 
 .nav-tabs .nav-link.active {
   background-color: $body-bg;
+  color: $primary;
   font-weight: 500;
   border-color: $lightslategray $lightslategray;
   border-bottom: 1px solid $body-bg;


### PR DESCRIPTION
## Description
This PR fixes an issue where the active tab text color on the white-labeling page did not match the Meshery design theme. It updates the SASS styles so that the active state now reflects the correct primary text color.

## Fixes Issue
Fixes #818

## Notes for Reviewers
Please verify that:
-The active tab text color now uses the proper theme variable.

## Screenshots

**Before:**

<img width="974" height="761" alt="Before: white-labeling active tab issue" src="https://github.com/user-attachments/assets/fd660fd1-ccfb-459b-8a0d-1af14ea53990" />

**After:**

<img width="1066" height="780" alt="After: white-labeling active tab fixed" src="https://github.com/user-attachments/assets/e64d11fc-f614-46de-b4f5-8091d858ce30" />

## [Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)
- [x] Yes, I signed my commits.

