### PR TITLE
docs: document Kanvas publish-to-catalog flow

### DIFF
--- a/content/en/cloud/catalog/_index.md
+++ b/content/en/cloud/catalog/_index.md
@@ -48,13 +48,13 @@ Catalog content is categorized in a number of ways:
 
 ### Publishing from Kanvas 🔗
 
-To publish a design from Meshery Kanvas (Playground) into the Cloud Catalog:
+To publish a design into the catalog:
 
-- Open your design in Kanvas (for example from **My Designs → Open in Playground**).
-- Click the **hamburger menu** in the top-left of Kanvas.
-- Choose **Share… → Publish to catalog**.
-- In the design details dialog, review or update the **name**, **type**, and **description**, then click **Publish To Catalog**.
-- After the request is submitted, maintainers approve it, and the design appears in the public Catalog at [cloud.layer5.io/catalog](https://cloud.layer5.io/catalog).
+1. Open your design in Kanvas (for example from **My Designs**).
+1. Click the **hamburger menu** in the top-left of Kanvas.
+1. Choose **Share… → Publish to catalog**.
+1. In the design details dialog, review or update the **name**, **type**, and **description**, then click **Publish To Catalog**.
+1. After the request is submitted, maintainers approve it, and the design appears in the [public catalog](https://cloud.layer5.io/catalog).
 
 ### Content Tags
 


### PR DESCRIPTION
Fixes layer5io/docs#852

This PR adds a short **“Publishing from Kanvas”** section to the Cloud Catalog docs
(`content/en/cloud/catalog/_index.md`), 

documenting how to publish a design from
Meshery Kanvas (Playground) into the Cloud Catalog using:

- Open design in Kanvas
- Hamburger menu → Share… → Publish to catalog
- Fill in name, type, description, then click **Publish To Catalog**

This helps contributors working on Meshery design issues understand how to publish
their designs from Playground so they appear in the Cloud Catalog.
