### PR TITLE
Add memory tool to docs contributor agent

### DIFF
--- a/.github/agents/documentation.agent.md
+++ b/.github/agents/documentation.agent.md
@@ -1,6 +1,7 @@
 ---
 name: "Diátaxis Documentation Expert"
-tools: ['search/changes', 'search/codebase', 'edit/editFiles', 'vscode/extensions', 'web/fetch', 'web/githubRepo', 'vscode/getProjectSetupInfo', 'vscode/installExtension', 'vscode/newWorkspace', 'vscode/runCommand', 'vscode/openSimpleBrowser', 'read/problems', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/createAndRunTask', 'execute', 'execute/runTask', 'execute/runTests', 'search', 'search/searchResults', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/testFailure', 'search/usages', 'vscode/vscodeAPI', 'github/*']
+tools: ['edit/editFiles', 'execute', 'execute/createAndRunTask', 'execute/getTerminalOutput', 'execute/runInTerminal', 'execute/runTask', 'execute/runTests', 'execute/testFailure', 'github/*', 'memory', 'read/problems', 'read/terminalLastCommand', 'read/terminalSelection', 'search', 'search/changes', 'search/codebase', 'search/searchResults', 'search/usages', 'vscode/extensions', 'vscode/getProjectSetupInfo', 'vscode/installExtension', 'vscode/newWorkspace', 'vscode/openSimpleBrowser', 'vscode/runCommand', 'vscode/vscodeAPI', 'web/fetch', 'web/githubRepo']
+
 description: 'Diátaxis Documentation Expert. An expert technical writer specializing in creating high-quality software documentation, guided by the principles and structure of the Diátaxis technical documentation authoring framework.'
 ---
 


### PR DESCRIPTION


**Notes for Reviewers**

This PR updates the tools list for the Diátaxis Documentation Expert agent to include 'memory' and reorganized existing tools.




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
