### PR TITLE
fix: replace deprecated Hugo site accessors

### DIFF
--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,7 +1,7 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Site.AllPages }}
+  {{ range site.AllPages }}
   {{- if and (not .Params.sitemap_exclude) (not .Draft) }}
   <url>
     <loc>{{ .Permalink }}</loc>

--- a/layouts/partials/feature-info.html
+++ b/layouts/partials/feature-info.html
@@ -1,5 +1,5 @@
 {{ $currentPage := .Page.Permalink }}
-{{ $features := .Site.Data.feature_data }}
+{{ $features := hugo.Data.feature_data }}
 {{ if not $features }}
 {{ with readFile "data/feature_data.json" }}
 {{ $features = . | transform.Unmarshal }}


### PR DESCRIPTION
## Summary
- replace deprecated .Site.Data access with hugo.Data
- replace deprecated .Site.AllPages access with site.AllPages
- remove the two Hugo deprecation sites behind issues #925 and #926

## Testing
- 
pm run build:production *(currently blocked locally because go is not installed in PATH for Hugo modules)*
- targeted search confirms no remaining .Site.Data or .Site.AllPages usages in layouts/

Closes #925
Closes #926