### PR TITLE
Remove unused `site-fast` target from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,6 @@ setup:
 ## Run docs.layer5.io on your local machine with draft and future content enabled.
 site: check-go
 	hugo server -D -F
-	
-## Run docs.layer5.io on your local machine. Alternate method.
-site-fast:
-	gatsby develop
 
 ## Build docs.layer5.io on your local machine.
 build:
@@ -36,7 +32,7 @@ clean:
 	hugo --cleanDestinationDir
 	make site
 
-.PHONY: setup build site clean site-fast check-go docker
+.PHONY: setup build site clean check-go docker
 
 check-go:
 	@echo "Checking if Go is installed..."


### PR DESCRIPTION
## Summary

- Removes the \`site-fast\` target from the repo Makefile. It invokes \`gatsby develop\`, but the docs site is now built with Hugo (see the \`site\`, \`build\`, and \`clean\` targets); the target cannot succeed on a clean checkout.
- Also removes \`site-fast\` from the \`.PHONY\` list.

Closes #945.

## Test plan

- [x] \`make -n site\`, \`make -n build\`, \`make -n clean\` still expand to the same Hugo invocations.
- [x] No other references to \`site-fast\` in the Makefile or in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)