### PR TITLE
fix(navbar): prevent undefined cloud profile URLs

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -328,8 +328,9 @@
   }
 
   function getUserProfileUrl(response) {
-    if (response && response.id !== undefined && response.id !== null && response.id !== "") {
-      return `${cloudAppUrl}/user/${encodeURIComponent(response.id)}`;
+    const userId = response?.id;
+    if (userId) {
+      return `${cloudAppUrl}/user/${encodeURIComponent(userId)}`;
     }
 
     return cloudAppUrl;
@@ -341,8 +342,10 @@
 
     const avatarUrl = getAvatarUrl(response);
     const avatarContainer = document.querySelector('.avatar-container');
-    avatarContainer.style.backgroundImage = avatarUrl ? `url("${avatarUrl}")` : "none";
-    avatarContainer.style.backgroundSize = avatarUrl ? "cover" : "";
+    if (avatarContainer) {
+      avatarContainer.style.backgroundImage = avatarUrl ? `url("${avatarUrl}")` : "none";
+      avatarContainer.style.backgroundSize = avatarUrl ? "cover" : "";
+    }
 
     const cloudLink = document.getElementById('user-profile-url');
     cloudLink.href = getUserProfileUrl(response);

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -189,7 +189,7 @@
             <a class="nav-link" href="https://cloud.layer5.io/login" target="_blank">Sign In</a>
           </li>
           <li class="nav-item dropdown" data-bs-theme="dark" id="userlist" style="display: none;">
-             <a href="" id="user-profile-url">
+             <a href="https://cloud.layer5.io" id="user-profile-url">
               <div
                 class="nav-link avatar-container"
                id="avatarDropdown"
@@ -260,6 +260,7 @@
       cur.href = "javascript: void(0)";
     }
   
+  const cloudAppUrl = "https://cloud.layer5.io";
   let isUserAuthenticated = false;
   let expiredToken = "";
 
@@ -288,7 +289,7 @@
         }
       throw new Error("missing or expired cookie");
     }
-      const re = await fetch("https://cloud.layer5.io/api/identity/users/profile", {
+      const re = await fetch(`${cloudAppUrl}/api/identity/users/profile`, {
         method: 'GET',
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -311,20 +312,40 @@
     showSignInButton();
   }
 };
-function updateUI(response) {
-document.getElementById('signin-button').style.display = 'none';
-document.getElementById("userlist").style.display = "block";
-const avatarUrl = response.avatar_url;
-const avatarContainer = document.querySelector('.avatar-container');
-avatarContainer.style.backgroundImage = `url("${avatarUrl}")`;
-avatarContainer.style.backgroundSize = 'cover';
+  function getAvatarUrl(response) {
+    if (
+      response &&
+      typeof response.avatar_url === "string" &&
+      response.avatar_url.trim()
+    ) {
+      return response.avatar_url.trim();
+    }
 
-const userId = response.id;
-const cloudLink = document.getElementById('user-profile-url');
-cloudLink.href = `https://cloud.layer5.io/user/${userId}`;
+    return "";
+  }
 
-isUserAuthenticated = true;
-}
+  function getUserProfileUrl(response) {
+    if (response && response.id !== undefined && response.id !== null && response.id !== "") {
+      return `${cloudAppUrl}/user/${encodeURIComponent(response.id)}`;
+    }
+
+    return cloudAppUrl;
+  }
+
+  function updateUI(response) {
+    document.getElementById('signin-button').style.display = 'none';
+    document.getElementById("userlist").style.display = "block";
+
+    const avatarUrl = getAvatarUrl(response);
+    const avatarContainer = document.querySelector('.avatar-container');
+    avatarContainer.style.backgroundImage = avatarUrl ? `url("${avatarUrl}")` : "none";
+    avatarContainer.style.backgroundSize = avatarUrl ? "cover" : "";
+
+    const cloudLink = document.getElementById('user-profile-url');
+    cloudLink.href = getUserProfileUrl(response);
+
+    isUserAuthenticated = true;
+  }
 
 function showSignInButton() {
       document.getElementById("userlist").style.display = "none";

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,3 +1,6 @@
+{{ $cloudAppUrl := "https://cloud.layer5.io" }}
+{{ $cloudAcademyUrl := printf "%s/academy" $cloudAppUrl }}
+{{ $cloudLoginUrl := printf "%s/login" $cloudAppUrl }}
 <header>
   <nav
     class="td-navbar navbar-dark js-navbar-scroll td-navbar-cover navbar-bg-onscroll--fade"
@@ -39,7 +42,7 @@
                         <div class="dropdown-menu dropdown-menu--col" aria-labelledby="resourcesDropdown" style="visibility:hidden;">
                           <a
                           class="dropdown-item dropdown-item--row"
-                          href="https://cloud.layer5.io/academy"
+                          href="{{ $cloudAcademyUrl }}"
                           target="_blank"
                           >
                             <div class="logo-container">
@@ -171,7 +174,7 @@
               <div class="dropdown-divider"></div>
               <a
                 class="dropdown-item"
-                href="https://cloud.layer5.io/academy"
+                href="{{ $cloudAcademyUrl }}"
                 target="_blank"
               >
                 <div class="logo-container">
@@ -186,10 +189,10 @@
             </div>
           </li>
           <li class="nav-item" id="signin-button" style="display: none;">
-            <a class="nav-link" href="https://cloud.layer5.io/login" target="_blank">Sign In</a>
+            <a class="nav-link" href="{{ $cloudLoginUrl }}" target="_blank">Sign In</a>
           </li>
           <li class="nav-item dropdown" data-bs-theme="dark" id="userlist" style="display: none;">
-             <a href="https://cloud.layer5.io" id="user-profile-url">
+             <a href="{{ $cloudAppUrl }}" id="user-profile-url">
               <div
                 class="nav-link avatar-container"
                id="avatarDropdown"
@@ -260,7 +263,7 @@
       cur.href = "javascript: void(0)";
     }
   
-  const cloudAppUrl = "https://cloud.layer5.io";
+  const cloudAppUrl = "{{ $cloudAppUrl }}";
   let isUserAuthenticated = false;
   let expiredToken = "";
 


### PR DESCRIPTION
## Summary
- guard against missing Cloud profile avatar URLs in the docs navbar
- fall back to the Cloud home page when the authenticated profile payload has no user ID
- stop authenticated visitors from triggering requests to /cloud/undefined

## Related Issue
Fixes #961