### PR TITLE
[Docs] Remove repetitive REST API reference summary text

### DIFF
--- a/layouts/partials/rest-apis/viewer.html
+++ b/layouts/partials/rest-apis/viewer.html
@@ -129,7 +129,6 @@
     <section class="rest-api-overview" aria-label="Layer5 Cloud REST API overview">
       <p class="rest-api-overview__eyebrow">Layer5 Cloud REST API reference</p>
       <p class="rest-api-overview__summary">
-        {{ len $operations }} API endpoints across {{ len $orderedTags }} resources.
         This reference is generated from the <a href="https://raw.githubusercontent.com/layer5io/docs/refs/heads/master/data/openapi.yml">OpenAPI schema</a> used by the Layer5 docs.
       </p>
       <ul class="rest-api-overview__stats">


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #964 by removing the redundant REST API summary sentence from the API reference overview. The endpoint and resource counts are still shown in the summary cards, so the page no longer repeats the same information in the same viewport.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
