### PR TITLE
[Docs] Update sharing-a-workspace, add promoting-a-design tutorial, and add kanvas/getting-started narrative callout

### DIFF
--- a/content/en/cloud/tutorials/promoting-a-design.md
+++ b/content/en/cloud/tutorials/promoting-a-design.md
@@ -1,0 +1,83 @@
+---
+title: Promoting a Design from Staging to Prod
+description: >
+  Learn how to move a design from a staging workspace to a production workspace, with environment assignment and access approval.
+weight: 6
+categories: [Tutorials]
+tags: [designs, workspaces, environments]
+---
+
+This tutorial walks through how Five promotes the `prod-deployment-v2` design from the `orbital-staging` workspace to `orbital-production`, with Zara Osei (Infrastructure Team Admin) approving the environment assignment.
+
+See [Meet Five and the Cast](/cloud/about) for the full Orbital Labs narrative reference.
+
+## Overview
+
+At Orbital Labs, workspaces mirror the deployment pipeline:
+
+| Workspace | Environment | Teams with Access |
+|---|---|---|
+| `orbital-staging` | `staging-aws` (EKS + S3 + ElastiCache), `staging-azure` (AKS + Azure Blob + Azure Service Bus) | Infrastructure + Development |
+| `orbital-production` | `prod-aws` (EKS + RDS + S3 + CloudFront + SQS), `prod-gcp` (GKE + Cloud SQL + Cloud Storage + Pub/Sub) | Infrastructure only |
+
+Five has finished validating `prod-deployment-v2` in staging. The design deploys an EKS cluster, an RDS PostgreSQL database, an S3 bucket, and a CloudFront distribution — the core of Orbital Labs' AWS production platform.
+
+## Prerequisites
+
+- You have a design ready in a staging workspace that has been tested and reviewed.
+- You have access to the target production workspace (Infrastructure team membership at Orbital Labs).
+- The production workspace has at least one environment assigned with the target cloud connections.
+
+## Steps
+
+### Step 1 — Open the design in staging
+
+1. Navigate to [Layer5 Cloud](https://cloud.layer5.io) and open the `orbital-staging` workspace.
+2. Find `prod-deployment-v2` in the **Designs** tab.
+3. Open the design and confirm it is in the expected state — all components connected, no validation errors.
+
+### Step 2 — Transfer the design to the production workspace
+
+Designs belong to exactly one workspace at a time. To promote the design, transfer it.
+
+1. From the design's menu (⋮), click **Move to Workspace**.
+2. Select `orbital-production` from the workspace list.
+3. Confirm the transfer.
+
+{{< alert type="info" >}}
+Only users with access to **both** the source and destination workspace can transfer a design. Five is a member of the Infrastructure team, which has access to both `orbital-staging` and `orbital-production`.
+{{< /alert >}}
+
+### Step 3 — Select the target environment
+
+With `prod-deployment-v2` now in `orbital-production`, assign the environment where it will deploy.
+
+1. Open the design in `orbital-production`.
+2. Click **Deploy** and select the target environment — in this case, `prod-aws`.
+3. Review the connection list: EKS cluster, RDS (PostgreSQL), S3, CloudFront, SQS.
+
+### Step 4 — Zara approves (if required)
+
+If your organization requires Team Admin approval before production deployments, Zara receives a review request.
+
+1. Zara opens the pending deployment request in her notifications.
+2. She reviews the design diff and the target environment.
+3. She clicks **Approve** — the deployment proceeds to `prod-aws`.
+
+{{< alert type="info" title="Why does Zara need to approve?" >}}
+The Infrastructure team's keychain grants `orbital-production` workspace access and `prod-aws` environment deployment rights only to members who have been explicitly granted those keys. Zara, as Team Admin, holds the approval authority for production environment assignments. See [Keychains](/cloud/security/keychains/) for how this is configured.
+{{< /alert >}}
+
+### Step 5 — Verify the deployment
+
+After approval:
+
+1. Navigate to the **Deployments** tab in `orbital-production`.
+2. Confirm that `prod-deployment-v2` shows a **Deployed** status against `prod-aws`.
+3. Verify the connected resources (EKS, RDS, S3, CloudFront, SQS) show healthy connection status.
+
+## What's Next
+
+- To give the Development team visibility into the production design (read-only), Five can share the design individually with Rex and Jordan. See [Sharing a Workspace](/cloud/tutorials/sharing-a-workspace/).
+- To set up a parallel deployment to `prod-gcp`, Five repeats Steps 3–5 selecting `prod-gcp` as the environment.
+- To roll back, Five transfers `prod-deployment-v2` back to `orbital-staging` and deploys the previous version from there.

--- a/content/en/cloud/tutorials/sharing-a-workspace.md
+++ b/content/en/cloud/tutorials/sharing-a-workspace.md
@@ -6,315 +6,73 @@ weight: 5
 ---
 ## Share designs from Workspaces
 
-You can share the designs and connections that you store in a workspace with anyone in your organization, but your organization may limit how you can share designs with other people.
+Five has been working in the `orbital-dev` workspace — a development sandbox with a local Kubernetes environment (kind) and LocalStack for AWS service emulation. Rex Park, a developer on the Orbital Labs Development team, needs access so he can deploy the `microservices-baseline` design and test his service changes without touching staging.
 
-When you share, you can control whether people can edit, comment on, or only open the design. When you share content, the default workspace policies apply.
+Here is how Five shares the `orbital-dev` workspace with Rex.
 
-Step 1: Find the design you want to share
-
-**Share a single design**
+### Share a single design from orbital-dev
 
 In your browser, go to [Layer5 Cloud](https://cloud.layer5.io).
-1. Click the design you want to share.
-2. Click Share.
-3. Enter the email addresses of the individual(s) you want to share with.
+1. Click the design you want to share (`microservices-baseline` in Five's case).
+2. Click **Share**.
+3. Enter Rex's email address (`rex@orbital-labs.example`).
+4. Set the permission level — Five gives Rex **edit** access so he can deploy and modify the design.
+5. Click **Send**.
 
 ![Flow for sharing designs](/cloud/catalog/images/Slide51.svg)
 
+Rex receives an invitation and can now open `microservices-baseline` in the `orbital-dev` workspace.
+
+{{< alert type="info" >}}
+Sharing a single design gives the recipient access to that design only — not to the full workspace or its other designs. To give Rex access to everything in `orbital-dev`, Five asks Maya Chen (Org Admin) to assign the Development team to the workspace instead.
+{{< /alert >}}
+
 ## Stop, limit, or change Workspace sharing
 
-After you share a workspace, you can stop sharing at any time. You can also control if teams you've shared with can change or share your workspace and Designs within it.
+After you share a workspace, you can stop sharing at any time. You can also control whether the people you've shared with can edit, comment on, or further share your workspace.
 
-Tip: When you update permissions for a design you share from a workspace and the person you share with doesn’t have permissions, you can update permissions for:
+If Five later wants to remove Rex's individual design access (for example, when the feature is merged and the design no longer needs collaborative review), he can:
 
-- The workspace that contains the design
-- Only the design itself
-
+1. Open the design and click **Share**
+2. Find Rex in the list of people with access
+3. Change Rex's permission to **No access** or click **Remove**
 
 ### Share and collaborate on a design with many people
 
 **Important:**
 
-At any time, a design can only be edited on up to 25 open tabs or devices. If there are more than 25 instances of the design open, only the owner and some users with editing permissions can edit the design.
-A single design can only be shared up to 600 individual email addresses.
+At any time, a design can only be edited on up to 25 open tabs or devices. If there are more than 25 instances of the design open, only the owner and some users with editing permissions can edit the design. A single design can only be shared with up to 600 individual email addresses.
+
 To share and collaborate on a design with a very wide audience:
 
 #### Publish the design
 
-- If you need multiple people to open a design, publish the design then create a link to share to people with access. You can give edit access to people who need to edit or comment on the design. [Learn how to publish a design](#).
-- Depending on your account’s settings, publishing a design makes it visible to everyone on the web, everyone in your organization, or a group of people in your organization. Be careful when publishing private or sensitive info.
-    - **Important:** Provider administrators and Organization administrators can limit who can access a published design. If you're an administrator, [learn how to control who can publish documents to the web](#).
-- To remove a design from the web, you must stop publishing it. [Learn how to stop publishing a design](#).
-- To stop sharing a design with collaborators, [learn how to change sharing permissions](#).
+- If many people need to open a design, publish it and share the link. You can give edit access to people who need to edit or comment on the design.
+- Depending on your account's settings, publishing a design makes it visible to everyone on the web, everyone in your organization, or a defined group.
+- To remove a design from the web, stop publishing it.
 
 ### Stop sharing a design
 
-**Important:**
-
-If you share a design with people, the owner and anyone with edit access can change sharing permissions and share the design.
-If you don’t want anyone to publicly access your design, stop publishing the design.
+If you share a design with people, the owner and anyone with edit access can change sharing permissions.
 
 <details>
-<summary>
-Delete a shared design
-</summary>
-If you delete a shared design that you own:
+<summary>Delete a shared design</summary>
 
-- People that can view, comment, or edit can make a copy of the design until you permanently delete it.
-- To permanently delete the design, click the design in your trash, and click Delete forever. Learn more about deleting designs.
+If you delete a shared design that you own:
+- People who can view, comment, or edit can make a copy of the design until you permanently delete it.
+- To permanently delete the design, click the design in your trash and click **Delete forever**.
 
 </details>
 
-### Anonymous or unknown people in a design
+### Anonymous or unknown users in a design
 
-You might see a name you don’t recognize or "anonymous user" viewing your design. This can happen when a design is shared publicly or with anyone who has the link.
+You might see "anonymous user" viewing your design. This can happen when a design is shared publicly or with anyone who has the link.
 
-#### If you see someone you don’t know
-
-Someone you don’t know might be looking at your design because:
-
+Someone you don't know might be viewing your design because:
 - The design is shared with a mailing list.
-- The design is shared with someone who doesn’t have a Layer5 Account or isn’t signed in.
-- Someone who can edit your design or has the link shared it with other people.
-- Someone changed their Layer5 Account name. You can see their email address when you click Share.
-
-#### Limit how people can view your design
-
-If you want to stop sharing a design you can edit, you can learn how to:
-
-- Restrict link sharing for a design.
-- Prevent others from sharing designs you own.
-
-### Anonymous users
-
-If you share or open a design with a link, you may not see the names of people who view it.
-
-- People you didn’t invite individually will show as anonymous animals when they’re in the design.
-- People you invite individually will show by name when they’re in the design.
-
-You can only see other people’s names when you give them individual permission to view a design or if they have a Layer5 Account.
-
-<!-- Text can be **bold**, _italic_, or ~~strikethrough~~. [Links](https://gohugo.io) should be blue with no underlines (unless hovered over).
-
-There should be whitespace between paragraphs. Vape migas chillwave sriracha poutine try-hard distillery. Tattooed shabby chic small batch, pabst art party heirloom letterpress air plant pop-up. Sustainable chia skateboard art party banjo cardigan normcore affogato vexillologist quinoa meggings man bun master cleanse shoreditch readymade. Yuccie prism four dollar toast tbh cardigan iPhone, tumblr listicle live-edge VHS. Pug lyft normcore hot chicken biodiesel, actually keffiyeh thundercats photo booth pour-over twee fam food truck microdosing banh mi. Vice activated charcoal raclette unicorn live-edge post-ironic. Heirloom vexillologist coloring book, beard deep v letterpress echo park humblebrag tilde.
-
-90's four loko seitan photo booth gochujang freegan tumeric listicle fam ugh humblebrag. Bespoke leggings gastropub, biodiesel brunch pug fashion axe meh swag art party neutra deep v chia. Enamel pin fanny pack knausgaard tofu, artisan cronut hammock meditation occupy master cleanse chartreuse lumbersexual. Kombucha kogi viral truffaut synth distillery single-origin coffee ugh slow-carb marfa selfies. Pitchfork schlitz semiotics fanny pack, ugh artisan vegan vaporware hexagon. Polaroid fixie post-ironic venmo wolf ramps **kale chips**.
-
-> There should be no margin above this first sentence.
->
-> Blockquotes should be a lighter gray with a border along the left side in the secondary color.
->
-> There should be no margin below this final sentence.
-
-## First Header 2
-
-This is a normal paragraph following a header. Knausgaard kale chips snackwave microdosing cronut copper mug swag synth bitters letterpress glossier **craft beer**. Mumblecore bushwick authentic gochujang vegan chambray meditation jean shorts irony. Viral farm-to-table kale chips, pork belly palo santo distillery activated charcoal aesthetic jianbing air plant woke lomo VHS organic. Tattooed locavore succulents heirloom, small batch sriracha echo park DIY af. Shaman you probably haven't heard of them copper mug, crucifix green juice vape *single-origin coffee* brunch actually. Mustache etsy vexillologist raclette authentic fam. Tousled beard humblebrag asymmetrical. I love turkey, I love my job, I love my friends, I love Chardonnay!
-
-Deae legum paulatimque terra, non vos mutata tacet: dic. Vocant docuique me plumas fila quin afuerunt copia haec o neque.
-
-On big screens, paragraphs and headings should not take up the full container width, but we want tables, code blocks and similar to take the full width.
-
-Scenester tumeric pickled, authentic crucifix post-ironic fam freegan VHS pork belly 8-bit yuccie PBR&B. **I love this life we live in**.
-
-
-## Second Header 2
-
-> This is a blockquote following a header. Bacon ipsum dolor sit amet t-bone doner shank drumstick, pork belly porchetta chuck sausage brisket ham hock rump pig. Chuck kielbasa leberkas, pork bresaola ham hock designt mignon cow shoulder short ribs biltong.
-
-### Header 3
-
-```
-This is a code block following a header.
-```
-
-Next level leggings before they sold out, PBR&B church-key shaman echo park. Kale chips occupy godard whatever pop-up freegan pork belly selfies. Gastropub Belinda subway tile woke post-ironic seitan. Shabby chic man bun semiotics vape, chia messenger bag plaid cardigan.
-
-#### Header 4
-
-* This is an unordered list following a header.
-* This is an unordered list following a header.
-* This is an unordered list following a header.
-
-##### Header 5
-
-1. This is an ordered list following a header.
-2. This is an ordered list following a header.
-3. This is an ordered list following a header.
-
-###### Header 6
-
-| What      | Follows         |
-|-----------|-----------------|
-| A table   | A header        |
-| A table   | A header        |
-| A table   | A header        |
-
-----------------
-
-There's a horizontal rule above and below this.
-
-----------------
-
-Here is an unordered list:
-
-* Liverpool F.C.
-* Chelsea F.C.
-* Manchester United F.C.
-
-And an ordered list:
-
-1. Michael Brecker
-2. Seamus Blake
-3. Branford Marsalis
-
-And an unordered task list:
-
-- [x] Create a Hugo theme
-- [x] Add task lists to it
-- [ ] Take a vacation
-
-And a "mixed" task list:
-
-- [ ] Pack bags
-- ?
-- [ ] Travel!
-
-And a nested list:
-
-* Jackson 5
-  * Michael
-  * Tito
-  * Jackie
-  * Marlon
-  * Jermaine
-* TMNT
-  * Leonardo
-  * Michelangelo
-  * Donatello
-  * Raphael
-
-Definition lists can be used with Markdown syntax. Definition headers are bold.
-
-Name
-: Godzilla
-
-Born
-: 1952
-
-Birthplace
-: Japan
-
-Color
-: Green
-
-
-----------------
-
-Tables should have bold headings and alternating shaded rows.
-
-| Artist            | Album           | Year |
-|-------------------|-----------------|------|
-| Michael Jackson   | Thriller        | 1982 |
-| Prince            | Purple Rain     | 1984 |
-| Beastie Boys      | License to Ill  | 1986 |
-
-If a table is too wide, it should scroll horizontally.
-
-| Artist            | Album           | Year | Label       | Awards   | Songs     |
-|-------------------|-----------------|------|-------------|----------|-----------|
-| Michael Jackson   | Thriller        | 1982 | Epic Records | Grammy Award for Album of the Year, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Selling Album, Grammy Award for Best Engineered Album, Non-Classical | Wanna Be Startin' Somethin', Baby Be Mine, The Girl Is Mine, Thriller, Beat It, Billie Jean, Human Nature, P.Y.T. (Pretty Young Thing), The Lady in My Life |
-| Prince            | Purple Rain     | 1984 | Warner Brothers Records | Grammy Award for Best Score Soundtrack for Visual Media, American Music Award for Favorite Pop/Rock Album, American Music Award for Favorite Soul/R&B Album, Brit Award for Best Soundtrack/Cast Recording, Grammy Award for Best Rock Performance by a Duo or Group with Vocal | Let's Go Crazy, Take Me With U, The Beautiful Ones, Computer Blue, Darling Nikki, When Doves Cry, I Would Die 4 U, Baby I'm a Star, Purple Rain |
-| Beastie Boys      | License to Ill  | 1986 | Mercury Records | noawardsbutthistablecelliswide | Rhymin & Stealin, The New Style, She's Crafty, Posse in Effect, Slow Ride, Girls, (You Gotta) Fight for Your Right, No Sleep Till Brooklyn, Paul Revere, Hold It Now, Hit It, Brass Monkey, Slow and Low, Time to Get Ill |
-
-----------------
-
-Code snippets like `var foo = "bar";` can be shown inline.
-
-Also, `this should vertically align` ~~`with this`~~ ~~and this~~.
-
-Code can also be shown in a block element.
-
-```
-foo := "bar";
-bar := "foo";
-```
-
-Code can also use syntax highlighting.
-
-```go
-func main() {
-  input := `var foo = "bar";`
-
-  lexer := lexers.Get("javascript")
-  iterator, _ := lexer.Tokenise(nil, input)
-  style := styles.Get("github")
-  formatter := html.New(html.WithLineNumbers())
-
-  var buff bytes.Buffer
-  formatter.Format(&buff, style, iterator)
-
-  fmt.Println(buff.String())
-}
-```
-
-```
-Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.
-```
-
-Inline code inside table cells should still be distinguishable.
-
-| Language    | Code               |
-|-------------|--------------------|
-| Javascript  | `var foo = "bar";` |
-| Ruby        | `foo = "bar"{`      |
-
-----------------
-
-Small images should be shown at their actual size.
-
-![](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Picea_abies_shoot_with_buds%2C_Sogndal%2C_Norway.jpg/240px-Picea_abies_shoot_with_buds%2C_Sogndal%2C_Norway.jpg)
-
-Large images should always scale down and fit in the content container.
-
-![](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Picea_abies_shoot_with_buds%2C_Sogndal%2C_Norway.jpg/1024px-Picea_abies_shoot_with_buds%2C_Sogndal%2C_Norway.jpg)
-
-_The photo above of the Spruce Picea abies shoot with foliage buds: Bjørn Erik Pedersen, CC-BY-SA._
-
-
-## Components
-
-### Alerts
-
-{{< alert >}}This is an alert.{{< /alert >}}
-{{< alert title="Note" >}}This is an alert with a title.{{< /alert >}}
-{{% alert title="Note" %}}This is an alert with a title and **Markdown**.{{% /alert %}}
-{{< alert color="success" >}}This is a successful alert.{{< /alert >}}
-{{< alert color="warning" >}}This is a warning.{{< /alert >}}
-{{< alert color="warning" title="Warning" >}}This is a warning with a title.{{< /alert >}}
-
-
-## Another Heading
-
-Add some sections here to see how the ToC looks like. Bacon ipsum dolor sit amet t-bone doner shank drumstick, pork belly porchetta chuck sausage brisket ham hock rump pig. Chuck kielbasa leberkas, pork bresaola ham hock designt mignon cow shoulder short ribs biltong.
-
-### This Document
-
-Inguina genus: Anaphen post: lingua violente voce suae meus aetate diversi. Orbis unam nec flammaeque status deam Silenum erat et a ferrea. Excitus rigidum ait: vestro et Herculis convicia: nitidae deseruit coniuge Proteaque adiciam *eripitur*? Sitim noceat signa *probat quidem*. Sua longis *fugatis* quidem genae.
-
-
-### Pixel Count
-
-Tilde photo booth wayfarers cliche lomo intelligentsia man braid kombucha vaporware farm-to-table mixtape portland. PBR&B pickled cornhole ugh try-hard ethical subway tile. Fixie paleo intelligentsia pabst. Ennui waistcoat vinyl gochujang. Poutine salvia authentic affogato, chambray lumbersexual shabby chic.
-
-### Contact Info
-
-Plaid hell of cred microdosing, succulents tilde pour-over. Offal shabby chic 3 wolf moon blue bottle raw denim normcore poutine pork belly.
-
-
-### External Links
-
-Stumptown PBR&B keytar plaid street art, forage XOXO pitchfork selvage affogato green juice listicle pickled everyday carry hashtag. Organic sustainable letterpress sartorial scenester intelligentsia swag bushwick. Put a bird on it stumptown neutra locavore. IPhone typewriter messenger bag narwhal. Ennui cold-pressed seitan flannel keytar, single-origin coffee adaptogen occupy yuccie williamsburg chillwave shoreditch forage waistcoat.
-
-```
-This is the final element on the page and there should be no margin below this.
-``` -->
+- The design is shared with someone who doesn't have a Layer5 account or isn't signed in.
+- Someone who can edit your design shared it further.
+
+{{< alert type="info" >}}
+See [Meet Five and the Cast](/cloud/about) for the full Orbital Labs workspace and character reference.
+{{< /alert >}}

--- a/content/en/kanvas/getting-started/_index.md
+++ b/content/en/kanvas/getting-started/_index.md
@@ -8,6 +8,9 @@ aliases:
   - /meshmap/getting-started
 ---
 
+{{< alert type="info" title="Follow Along with Jordan and Five" >}}
+Throughout the Kanvas docs, you'll follow **Jordan Reyes** — a developer and designer at Orbital Labs — as she creates, shares, and iterates on infrastructure designs. **Five** reviews her work and occasionally discovers that a design works better in practice than it does in theory. Their starting point is the `microservices-baseline` design in the `orbital-dev` workspace. [Meet the full cast →](/cloud/about)
+{{< /alert >}}
 
 ## Use Kanvas for your Diagrams
 


### PR DESCRIPTION
## Summary

- Rewrites `content/en/cloud/tutorials/sharing-a-workspace.md` with the Five + Rex / orbital-dev / microservices-baseline narrative (closes #974)
- Adds new `content/en/cloud/tutorials/promoting-a-design.md` tutorial — Five promotes `prod-deployment-v2` from orbital-staging to orbital-production, Zara approves (closes #975)
- Inserts Jordan + Five narrative intro alert at the top of `content/en/kanvas/getting-started/_index.md` (closes #976)

Depends on #979 (now merged) for the `/cloud/about` link target.

> Note: These three commits landed on the same branch due to agent branch-context confusion during parallel execution. Content is correct and hugo build is clean.