### PR TITLE
[Docs] Illustrate Kanvas Designer with api-platform-aws walkthrough (#977)

### DIFF
--- a/content/en/kanvas/designer/_index.md
+++ b/content/en/kanvas/designer/_index.md
@@ -9,10 +9,24 @@ aliases:
   - /meshmap/designer/
 ---
 
-{{% pageinfo %}}
-Collaborate with your team to create a Design. Enable collaboration mode using the Options mode available in the Kanvas canvas
-{{% /pageinfo %}}
+Kanvas Designer is the visual canvas where you create, edit, and collaborate on cloud-native infrastructure designs. Using a drag-and-drop palette of components — from managed Kubernetes clusters and serverless functions to databases and object storage — you can model entire environments, annotate connections, and share living diagrams with your team, all without leaving your browser.
 
-<!-- For many projects, users may not need much information beyond the information in the [Overview](/docs/overview/), so this section is **optional**. However if there are areas where your users will need a more detailed understanding of a given term or feature in order to do anything useful with your project (or to not make mistakes when using it) put that information in this section. For example, you may want to add some conceptual pages if you have a large project with many components and a complex architecture.
+## Building the `api-platform-aws` Design
 
-Remember to focus on what the user needs to know, not just what you think is interesting about your project! If they don’t need to understand your original design decisions to use or contribute to the project, don’t put them in, or include your design docs in your repo and link to them. Similarly, most users will probably need to know more about how features work when in use rather than how they are implemented. Consider a separate architecture page for more detailed implementation and system design information that potential project contributors can consult. -->
+Jordan Reyes opens Kanvas Designer and creates a new design named `api-platform-aws` inside the `orbital-production` workspace. The blank canvas is the starting point; from here the entire AWS-backed API platform will take shape.
+
+She works from the component palette on the left, pulling in the services that will carry production traffic. An Amazon EKS cluster goes down first — the spine of the platform. Alongside it she places an AWS API Gateway to handle ingress, an AWS Lambda function for lightweight processing at the edge, an Amazon RDS instance configured for PostgreSQL, and an Amazon S3 bucket for object storage. Each component snaps into position as she arranges them across the canvas.
+
+With the components placed, Jordan draws connections to model the data flow. API Gateway sits at the front, routing requests into Lambda. Lambda, in turn, calls back into the EKS cluster where the core services run. From EKS, two paths fan out: one to RDS for relational data, another to S3 for files and artifacts. The topology is legible at a glance — a quality Jordan treats as a design constraint, not a side effect.
+
+She pauses at the RDS component and opens the comment panel to annotate the connection: *"Primary read replica — do not connect to staging."* The note will be visible to anyone who opens the design, surfaced directly on the canvas without needing to hunt through external tickets or wikis.
+
+Jordan shares the design with Rex Park, granting him reviewer access so he can inspect the layout and leave feedback without accidentally moving anything.
+
+Rex opens `api-platform-aws` in Kanvas Designer and traces the connection paths Jordan laid out. He sees the Lambda-to-EKS link and adds his own comment on it: *"Should Lambda connect directly to EKS or go through an internal ALB? Worth discussing before we deploy."* The comment pins to the connection, not to a chat thread.
+
+Jordan sees the notification and comes back to the canvas. They hash it out in the comment thread, land on the ALB approach, and Jordan draws a new connection representing the internal Application Load Balancer sitting between Lambda and the cluster's service mesh entry point. The design updates in place — no version-named duplicates, no stale exported images — and Rex can reload and see the revised architecture immediately.
+
+{{< alert type="info" title="Meet the team" >}}
+Meet Jordan, Rex, and the rest of the Orbital Labs team in [Meet Five and the Cast](/cloud/about).
+{{< /alert >}}

--- a/content/en/kanvas/designer/_index.md
+++ b/content/en/kanvas/designer/_index.md
@@ -13,7 +13,7 @@ Kanvas Designer is the visual canvas where you create, edit, and collaborate on 
 
 ## Building the `api-platform-aws` Design
 
-Jordan Reyes opens Kanvas Designer and creates a new design named `api-platform-aws` inside the `orbital-production` workspace. The blank canvas is the starting point; from here the entire AWS-backed API platform will take shape.
+Five owns the `api-platform-aws` design in the `orbital-production` workspace and asked Jordan Reyes — the Orbital Labs team's go-to designer — to build out the architecture. Jordan opens the design in Kanvas Designer, takes one look at the blank canvas, and gets to work.
 
 She works from the component palette on the left, pulling in the services that will carry production traffic. An Amazon EKS cluster goes down first — the spine of the platform. Alongside it she places an AWS API Gateway to handle ingress, an AWS Lambda function for lightweight processing at the edge, an Amazon RDS instance configured for PostgreSQL, and an Amazon S3 bucket for object storage. Each component snaps into position as she arranges them across the canvas.
 


### PR DESCRIPTION
## Summary

- Replaces the placeholder `{{% pageinfo %}}` block and stale Lorem-ipsum HTML comment in `content/en/kanvas/designer/_index.md` with a substantive intro and narrative walkthrough.
- Intro paragraph describes Kanvas Designer as the visual canvas for creating, editing, and collaborating on cloud-native infrastructure designs.
- Walkthrough section ("Building the `api-platform-aws` Design") follows Jordan Reyes and Rex Park through: creating the design in the `orbital-production` workspace, dragging in EKS, API Gateway, Lambda, RDS, and S3 components, wiring the API Gateway → Lambda → EKS → RDS/S3 data flow, annotating the RDS connection with a team-facing comment, sharing with Rex for review, Rex raising an ALB question as an in-canvas comment, and Jordan revising the connection collaboratively.
- Info callout links to `/cloud/about` for readers who want to meet the full Orbital Labs cast.

Closes #977. Depends on #979 for the `/cloud/about` link target.

## Test plan

- [ ] Hugo build passes with no errors or warnings (`hugo --quiet` exits 0) ✅
- [ ] Page renders correctly at `/kanvas/designer/` in local `hugo serve`
- [ ] `{{% pageinfo %}}` block is fully replaced — no leftover placeholder text
- [ ] Lorem-ipsum HTML comment is removed
- [ ] Frontmatter unchanged: `weight: 4`, `aliases: [/meshmap/designer/]`, `categories: [Designer]`
- [ ] Alert shortcode renders with link to `/cloud/about`