### PR TITLE
fix:correct timestamp format in release

### DIFF
--- a/layouts/release/list.html
+++ b/layouts/release/list.html
@@ -14,7 +14,7 @@
 	{{ .Content }}
 	{{ range .RegularPages.ByDate.Reverse }}
 	  <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
-	  <p>{{ .Date.Format "Monday, Jan 02, 2006 15:04:05 CST" }}</p>
+	  <p>{{ .Date.Format "Monday, Jan 02, 2006 15:04:05 MST" }}</p>
 	{{ end }}
 	</section>
 	

--- a/layouts/release/list.html
+++ b/layouts/release/list.html
@@ -14,7 +14,7 @@
 	{{ .Content }}
 	{{ range .RegularPages.ByDate.Reverse }}
 	  <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
-	  <p>{{ .Date.Format "Monday, Jan 2nd, 2025 15:04:05 CST" }}</p>
+	  <p>{{ .Date.Format "Monday, Jan 02, 2006 15:04:05 CST" }}</p>
 	{{ end }}
 	</section>
 	


### PR DESCRIPTION
This PR fixes #997

Fixes timestamp formatting in the release listing.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.