### PR TITLE
docs(cloud/identity): document authentication flows and custom-domain scenarios

### DIFF
--- a/content/en/cloud/identity/authentication/_index.md
+++ b/content/en/cloud/identity/authentication/_index.md
@@ -1,0 +1,62 @@
+---
+title: Authentication
+description: >
+  How Layer5 Cloud authenticates users, the sign-in flows it supports, and how organization context is carried across custom domains.
+weight: 4
+categories: [Identity]
+tags: [authentication, sso, oauth, oidc, custom-domains]
+---
+
+Layer5 Cloud authenticates every user through a unified identity layer that supports email-and-password sign-in, single sign-on with OAuth/OIDC providers (GitHub, Google), email-link verification, and self-service password recovery. Once a user is authenticated, the platform pins each request to the correct organization tenant — including organizations that have been mapped to a custom domain.
+
+## How authentication is structured
+
+Layer5 Cloud's authentication subsystem is built on three components that work together:
+
+* **Layer5 Cloud Server** — the only system the browser talks to during a sign-in. It owns the user-facing pages (`/login`, `/registration`, `/recovery`, `/verification`, `/password-reset`, `/reset`, `/account`), proxies every step of the underlying identity flow, and sets the cookies that establish your session.
+* **Ory Kratos** — the identity-management engine that handles user accounts, credentials (passwords, OIDC), email verification, password recovery, and account-settings changes. Kratos is never exposed directly to the browser; it sits behind the cloud server.
+* **Ory Hydra** — the OAuth 2.0 / OpenID Connect authorization server that issues the access tokens used by Layer5 Cloud and by Meshery instances acting as clients of the Remote Provider.
+
+This separation is the reason every authentication action you take in the browser hits a `/api/auth/...` URL on Layer5 Cloud rather than a Kratos URL. The browser never needs to know that Kratos exists.
+
+```
+Browser  ──►  Layer5 Cloud Server  ──►  Ory Kratos / Ory Hydra
+```
+
+{{< alert type="info" >}}
+For an explanation of how API access tokens differ from browser session cookies, see [Tokens](/cloud/security/tokens) and [Sessions](/cloud/security/sessions).
+{{< /alert >}}
+
+## What this section covers
+
+* [**Authentication flows**](/cloud/identity/authentication/authentication-flows) — every sign-in, sign-up, and account-management flow Layer5 Cloud supports, with step-by-step walkthroughs of what the browser, the cloud server, and Kratos each do at every hop. Covers email registration, email login, email verification, GitHub and Google OAuth (signup and login), password recovery and reset, account-settings (link/unlink providers, change password), anonymous-user handover, invitation acceptance, and logout.
+* [**Custom domains**](/cloud/identity/authentication/custom-domains) — how Layer5 Cloud routes authenticated traffic when a tenant organization has been mapped to its own custom domain (e.g. `academy.layer5.io`, `exoscale.layer5.io`, `cloud.meshery.io`). Covers the six sources of organization context, the cookie scopes that make cross-domain navigation work, and every redirect scenario that arises when a user's preferred organization differs from the domain they are currently on.
+
+## Two related but distinct concepts
+
+Two ideas that often get conflated are kept separate throughout this section:
+
+| Concept | Meaning | Source of truth |
+|---|---|---|
+| **Acting org** (scope) | The organization context for the current request — what the server reads from and writes to. | The hostname (custom domain), or the `Layer5-Current-Orgid` header / cookie / preference fallback. |
+| **Selected org** (intent) | The organization the user *wants* to be looking at. | `users.preferences.selectedOrganizationId` in the user's profile. |
+
+When intent and scope conflict — for instance, you are on `cloud.layer5.io` but your selected org has its own custom domain — Layer5 Cloud changes the **scope** (redirects you to the matching domain), not your **intent** (your preference is preserved).
+
+## Authentication providers
+
+Out of the box, Layer5 Cloud supports the following sign-in methods:
+
+* **Email and password**, with email verification, "have I been pwned" leaked-credential checking, and self-service password recovery via one-time-code email link.
+* **GitHub** via OAuth 2.0 / OpenID Connect. Requested scopes: `read:user`, `user:email`.
+* **Google** via OAuth 2.0 / OpenID Connect. Requested scopes: `email`, `profile`.
+
+Linking and unlinking these providers from a single user account is performed via the **Account Settings** flow (`/account`). See [User Accounts → Account Linking](/cloud/identity/users/#account-linking) for the user-facing rules, and [Authentication Flows → Account settings](/cloud/identity/authentication/authentication-flows/#account-settings-link--unlink--change-password) for the underlying mechanics.
+
+## Where authentication fits in the broader stack
+
+Layer5 Cloud also serves as a [Remote Provider for Meshery](https://docs.meshery.io/extensibility/providers). When a self-hosted Meshery instance is configured to use Layer5 Cloud as its provider, Meshery delegates user identity, organization membership, and access tokens to the same flows documented here. From the Meshery user's perspective, "log in to Meshery" and "log in to Layer5 Cloud" are the same act — Meshery redirects to Layer5 Cloud's `/login`, the user authenticates, and Hydra issues the access token that Meshery uses for subsequent API calls.
+
+{{< alert type="info" >}}
+If you are running a self-hosted Layer5 Cloud and want to bootstrap the initial Provider Admin organization, see the `INIT_CONFIG` environment variable documented in the [self-hosted setup](/cloud/self-hosted/) section.
+{{< /alert >}}

--- a/content/en/cloud/identity/authentication/authentication-flows.md
+++ b/content/en/cloud/identity/authentication/authentication-flows.md
@@ -308,7 +308,7 @@ The same allowlist that preserves `anonymousUserID` also carries:
 * `login_challenge` — Hydra OAuth2 continuation token. Dropping it would force a fresh OAuth flow and the user would land on `/login` instead of completing the in-progress flow.
 * `refresh=true` — instructs Kratos to enforce re-authentication regardless of the existing session.
 * `return_to` — explicit deep-link to land on after authentication.
-* `program` — used by enrolment flows tied to specific learning programmes.
+* `program` — used by enrollment flows tied to specific learning programs.
 * `orgId` — pre-selects an organization context for the auth pages (see [Custom domains](/cloud/identity/authentication/custom-domains)).
 
 ---

--- a/content/en/cloud/identity/authentication/authentication-flows.md
+++ b/content/en/cloud/identity/authentication/authentication-flows.md
@@ -7,7 +7,7 @@ categories: [Identity]
 tags: [authentication, oauth, oidc, kratos, hydra, signup, login, logout, recovery, github, google]
 ---
 
-This page catalogues every authentication flow Layer5 Cloud exposes to end users. Each flow is described from three perspectives: the user-visible journey, the HTTP / cookie behaviour underneath, and the entry-points and exit-points used by integrators (deep-links, redirect parameters, downstream flows).
+This page catalogs every authentication flow Layer5 Cloud exposes to end users. Each flow is described from three perspectives: the user-visible journey, the HTTP / cookie behavior underneath, and the entry-points and exit-points used by integrators (deep-links, redirect parameters, downstream flows).
 
 ## Common architecture
 
@@ -41,7 +41,7 @@ Three properties hold for **every** flow on this page:
 
 1. **The browser never POSTs to Kratos directly.** The form action is always `/api/auth/flow/submit?type=<flow-type>&id=<flow-id>` on the cloud server.
 2. **The browser never redirects to a Kratos URL.** Every server hop ends at a cloud-server path (`/api/auth/...`).
-3. **Cookies relayed from Kratos are rewritten** so they survive the proxy: the `Domain` attribute is stripped (the cookie binds host-only to the cloud server origin), and `Path` is normalised to `/` so the browser sends them on `/api/auth/flow/submit`. Other attributes — `Name`, `Value`, `MaxAge`, `Expires`, `Secure`, `HttpOnly`, `SameSite` — pass through unchanged.
+3. **Cookies relayed from Kratos are rewritten** so they survive the proxy: the `Domain` attribute is stripped (the cookie binds host-only to the cloud server origin), and `Path` is normalized to `/` so the browser sends them on `/api/auth/flow/submit`. Other attributes — `Name`, `Value`, `MaxAge`, `Expires`, `Secure`, `HttpOnly`, `SameSite` — pass through unchanged.
 
 These invariants are what allow Layer5 Cloud to look like a first-party application even though Kratos and Hydra are doing the heavy lifting under the hood.
 
@@ -55,11 +55,21 @@ The cloud server's flow proxy maps the five Kratos flow types onto the five corr
 | `registration` | `/self-service/registration` | `/registration`   | 24 hours       |
 | `verification` | `/self-service/verification` | `/verification`   | 30 days        |
 | `recovery`     | `/self-service/recovery`     | `/recovery`       | 30 days        |
-| `settings`     | `/self-service/settings`     | `/reset`          | 24 h privileged window |
+| `settings`     | `/self-service/settings`     | `/reset`          | 24 hours privileged window |
 
 The submit-proxy (`/api/auth/flow/submit`) enforces a 1 MiB request-body cap and a 30-second timeout to Kratos. Oversize bodies return `413 Request Entity Too Large`; transport failures to Kratos return `502 Bad Gateway`.
 
 ### Cookies set during authentication
+
+Layer5 Cloud uses three categories of cookies during sign-in. They are distinct — don't conflate them:
+
+* **Kratos session cookie** (`session_cookie`) — the Kratos-issued cookie that proves the user has an active Kratos identity. Required by Kratos's own `/self-service/settings` flow.
+* **OAuth2 access-token cookie** (`provider_token`) — the Hydra-issued OAuth2 access token, used for every authenticated cloud-server API call and forwarded to Meshery instances acting as Layer5 Cloud clients. This is the cookie that gates day-to-day API access.
+* **Browser-side workflow cookies** (`Layer5-Current-Orgid`, `new_user`, `source_ref`, `return_to`, `meshery_ref`, `_meshery_saas_ref`, `anonymousUserID`) — short-lived state used to drive the auth pages, themes, and post-login redirect.
+
+{{< alert type="info" >}}
+The [Sessions](/cloud/security/sessions) page describes the user-visible session that ties these cookies together; the cookie name `meshery_session` referenced there is the legacy single-cookie name from before the Kratos/Hydra split. Today, the equivalent state lives across the `session_cookie` (Kratos) and `provider_token` (Hydra OAuth2) cookies described below.
+{{< /alert >}}
 
 | Cookie | Set by | Scope | Lifetime | Purpose |
 |---|---|---|---|---|
@@ -103,10 +113,10 @@ The user creates a Layer5 Cloud account from scratch using an email address and 
 4. Open the email, click **Verify**, and you'll be bounced through the [email-verification flow](#email-verification) into `/login`.
 5. Log in with the credentials you just set. You land on `/dashboard`.
 
-**Behaviour notes**
+**Behavior notes**
 
 * The form posts to `/api/auth/flow/submit?type=registration&id=<flow-id>`.
-* Validation happens client-side first: name regex (`^[\p{L}\p{M}\s]{1,50}$/u`, accepts unicode letters and marks but no digits or symbols), an RFC-leaning email regex, and a spam filter that blocks listed names and email domains.
+* Validation happens client-side first: name regex (`^[\p{L}\p{M}\s]{1,50}$`, accepts unicode letters and marks but no digits or symbols), an RFC-leaning email regex, and a spam filter that blocks listed names and email domains.
 * Password rules are enforced server-side by Kratos: minimum 8 characters, identifier-similarity check (your password may not be substantially similar to your email), and a "have I been pwned" check against the public breach corpus.
 * The reCAPTCHA token, when present, is sent as a hidden input named `transient_payload` with value `{"recaptcha_token":"<token>"}`.
 * The flow lasts 24 hours from creation; expired flows return a fresh one via `/api/auth/flow/init`.
@@ -124,7 +134,7 @@ Verifying an email address is the second half of [email registration](#email-reg
 2. The page server-renders the `passed_challenge` state and immediately redirects you to `/login`.
 3. Sign in normally.
 
-**Behaviour notes**
+**Behavior notes**
 
 * Verification flows are valid for 30 days but each `flow=<id>` is single-use. If the link has expired or been used, the cloud server bounces the browser through `/api/auth/flow/init` to mint a fresh flow that asks the user to re-enter their email.
 * For users who registered via OAuth, email verification is implicit — the OAuth provider has already attested the address, so Kratos marks the identity as verified at registration time.
@@ -145,16 +155,14 @@ The standard sign-in flow for users who registered with an email address and pas
 
 **Where you land after signing in**
 
-The post-login destination is selected in this order:
+The post-login destination is selected in this order (highest priority first):
 
-1. **`?ref=` query parameter** on the URL that started the auth flow — used by trusted upstream systems (e.g. a Meshery server) to hand off a deep-link.
-2. **`meshery_ref` cookie** set by a Meshery instance acting as a Layer5 Cloud client.
-3. **`return_to` / `source_ref` cookie** captured at the start of the flow from the request URL — but **only** when the original request was a real top-level browser navigation (`Sec-Fetch-Dest: document`, method `GET`, and not a static-asset path or a `/.well-known/...` probe). Background fetches (favicon requests, service-worker probes, the Chrome DevTools `/.well-known/appspecific/com.chrome.devtools.json` probe, XHR, sub-resource loads) are deliberately ignored so they don't poison the post-login destination.
+1. **`meshery_ref` cookie** set by a Meshery instance acting as a Layer5 Cloud client. When present, this overrides everything else — a Meshery client is explicitly handing off a destination it controls.
+2. **`?ref=` query parameter** on the URL that started the auth flow — used by trusted upstream systems (e.g. a Meshery server) to hand off a deep-link.
+3. **The synthesized request URL** (encoded into the `return_to` / `source_ref` cookie at the start of the flow) — but **only** when the original request was a real top-level browser navigation (`Sec-Fetch-Dest: document`, method `GET`) AND the path is not itself an auth-initiation route (`/login`, `/registration`, `/callback`, `/logout`). Background fetches (favicon requests, service-worker probes, the Chrome DevTools `/.well-known/appspecific/com.chrome.devtools.json` probe, XHR, sub-resource loads) are deliberately ignored so they don't poison the post-login destination.
 4. **`/dashboard`** as the default fallback.
 
-The capture step also explicitly skips paths that *are* the auth flow itself (`/login`, `/registration`, `/callback`, `/logout`) so the user can't end up looped back into sign-in after they finish signing in.
-
-**Behaviour notes**
+**Behavior notes**
 
 * On invalid password, Kratos returns the existing flow with an error message attached and the user re-renders the same `/login?flow=<id>` page with the message inlined next to the relevant field.
 * On expired flow (HTTP `410 Gone` from Kratos), the cloud server bounces the browser back through `/api/auth/flow/init` to mint a new one — the user sees a fresh `/login` page, never an error.
@@ -176,7 +184,7 @@ Single sign-on registration via GitHub, using OAuth 2.0 / OpenID Connect.
 5. A registration webhook fires server-side, creating the corresponding row in the `users` table and provisioning the user's default workspace.
 6. Hydra issues the access token, the cloud server sets the `provider_token` cookie, and you land on `/registered` (and then `/dashboard`).
 
-**Behaviour notes**
+**Behavior notes**
 
 * The button label `Sign up with GitHub` comes directly from Kratos's flow JSON (`flow.ui.nodes[].meta.label.text`). Login flows return "Sign in with GitHub"; registration flows return "Sign up with GitHub".
 * OIDC submits skip the registration page's name/email/spam-filter validation entirely — GitHub supplies those fields, and they're populated server-side after the callback.
@@ -195,7 +203,7 @@ Subsequent sign-ins for an account that was either originally registered via Git
 3. GitHub consent (skipped if you have an active GitHub session and previously authorized Layer5 Cloud).
 4. Land on `/dashboard` with a valid access token.
 
-**Critical assertion**: after the OIDC round-trip the browser must not see a `401`. If it does, the most likely cause is the cookie `Path` attribute — the cloud server's cookie-relay normalises Kratos's native `Path=/.ory/kratos/public/` to `Path=/`; if that has been bypassed, the next form post will fail CSRF.
+**Critical assertion**: after the OIDC round-trip the browser must not see a `401`. If it does, the most likely cause is the cookie `Path` attribute — the cloud server's cookie-relay normalizes Kratos's native `Path=/.ory/kratos/public/` to `Path=/`; if that has been bypassed, the next form post will fail CSRF.
 
 ---
 
@@ -212,7 +220,7 @@ Single sign-on registration via Google, using OAuth 2.0 / OpenID Connect.
 5. The same registration webhook as the GitHub flow fires, creating the user record and the default workspace.
 6. Hydra issues the access token, the cloud server sets the `provider_token` cookie, and you land on `/registered` (and then `/dashboard`).
 
-**Behaviour notes**
+**Behavior notes**
 
 * The button label `Sign up with Google` is supplied by Kratos's flow JSON.
 * The user's `provider` field is set to `google`; their `userId` is set to the Google account's stable identifier.
@@ -245,7 +253,7 @@ Self-service flow for users who have forgotten their password.
 4. Enter and confirm a new password, then submit.
 5. You're redirected to `/login`. Sign in with the new password.
 
-**Behaviour notes**
+**Behavior notes**
 
 * The wording at step 2 is intentionally non-committal — the response does not disclose whether the email is registered, to prevent enumeration.
 * Recovery flows are valid for 30 days, but the one-time code in the email link is single-use.
@@ -274,7 +282,7 @@ Lets a signed-in user change their password, attach an additional credential met
 5. **Unlinking a provider** — Kratos validates that you still have at least one usable credential method left. You can never remove the only credential method on the account.
 6. **Changing a password** — Kratos enforces the same minimum-length / leaked-credential rules as the registration flow.
 
-**Behaviour notes**
+**Behavior notes**
 
 * The settings flow has a 24-hour `privileged_session_max_age`. If you signed in more than 24 hours ago, Kratos will require a fresh sign-in before allowing destructive changes (set/change password, unlink, etc.).
 * Linking is keyed on the email address Kratos receives from the provider — so if you sign up with `alice@example.com` via password and later try to **sign in** (not link) with a GitHub account whose primary email is `alice@example.com`, you'll be prompted for the existing password and the linking happens automatically. See [User Accounts → Account Linking](/cloud/identity/users/#account-linking) for the full rules.
@@ -329,14 +337,14 @@ Logout terminates the user's session on Layer5 Cloud and revokes the OAuth2 acce
 **User journey**
 
 1. Click your avatar in the header and choose **Sign out**.
-2. The browser hits Layer5 Cloud's logout handler. Three things happen in order:
-   * The cloud server calls Hydra's `RevokeToken` endpoint with the current `provider_token`. Hydra invalidates the token; subsequent calls with that token return `401 Unauthorized` even before the cookie expires.
-   * The Kratos session cookie is cleared by sending a `Set-Cookie: <name>=; Max-Age=-1; Path=/`. This terminates the Kratos session that backs the `/account` settings flow.
-   * The `provider_token` cookie is cleared on every domain it was set on (the eTLD+1-scoped copy and the host-scoped copy).
+2. The browser hits Layer5 Cloud's logout handler. Two things happen:
+   * The cloud server calls Hydra's `RevokeToken` endpoint with the current `provider_token`. **Hydra invalidates the token immediately** — subsequent API calls bearing that token return `401 Unauthorized`, regardless of whether the cookie itself has expired.
+   * The Kratos session cookie (`session_cookie` / `KratosCookieName`) is cleared by sending a `Set-Cookie: ...; Max-Age=-1; Path=/`. This terminates the Kratos session that backs the `/account` settings flow.
 3. Kratos's `flows.logout.after.default_browser_return_url` is configured to `/login`, so the browser lands on the login page.
 
-**Behaviour notes**
+**Behavior notes**
 
+* The `provider_token` cookie itself is *not* explicitly cleared by `RevokeToken` — the cookie can persist client-side until its 24-hour expiry, but the token it contains is dead the moment Hydra revokes it. Backend authorization checks see the revoked token and return `401`.
 * Logout is a single-page event — the user's browser is the only client invalidated. If you are signed in on a different device, that session is unaffected; revoke it from [Sessions](https://cloud.layer5.io/security/sessions) instead.
 * API tokens (Personal Access Tokens) are not affected by the browser logout. To revoke an API token, see [Tokens](/cloud/security/tokens).
 * If a Meshery instance is using your Layer5 Cloud session, that Meshery instance will receive `401` responses for its next API call and prompt the user to re-authenticate.
@@ -347,14 +355,14 @@ Logout terminates the user's session on Layer5 Cloud and revokes the OAuth2 acce
 
 | Symptom | First thing to check |
 |---|---|
-| `401 Unauthorized` immediately after an OIDC round-trip | The session cookie set by Kratos must have `Path=/` (so the browser sends it on `/api/auth/flow/submit`). The cloud server's cookie-relay normalises this; if it has been bypassed, you'll see the cookie restricted to `/.ory/...` and the next form post will fail CSRF. |
+| `401 Unauthorized` immediately after an OIDC round-trip | The session cookie set by Kratos must have `Path=/` (so the browser sends it on `/api/auth/flow/submit`). The cloud server's cookie-relay normalizes this; if it has been bypassed, you'll see the cookie restricted to `/.ory/...` and the next form post will fail CSRF. |
 | OAuth button does nothing on the registration page | HTML5 form validation is blocking. The OIDC submit button must carry `formNoValidate`. |
 | Form submit fails CSRF on the very first attempt | The `/api/auth/flow/init` response must include the CSRF cookie — check `Set-Cookie` is present and `Path=/`. |
 | `/registration?flow=<id>` redirects to a 404 page | `KRATOS_BROWSER_URL` has been re-exposed to the JavaScript bundle by mistake. The public UI must treat Kratos as if it doesn't exist. |
 | Anonymous designs disappear after signup | Trace `anonymousUserID` through every redirect. It must appear in `/api/auth/flow/init`, in the post-init bounce-back, and in the `source_ref` cookie that the post-auth handler reads to trigger `MigrateUserResourceToCurrentUser`. |
 | `413 Request Entity Too Large` on form submit | Body exceeded the 1 MiB cap on the submit proxy. Legitimate flows do not approach this; investigate what is being submitted. |
 | Form submit hangs | The cloud server enforces a 30-second timeout to Kratos. A hang past this point indicates Kratos itself is slow or unreachable. |
-| Logout button "did nothing" — user is still signed in | Check both `provider_token` cookies (eTLD+1-scoped and host-scoped, on custom domains). Both must be cleared. |
+| Logout button "did nothing" — user is still signed in | Confirm Hydra's `RevokeToken` returned 200, and confirm the Kratos `session_cookie` was cleared. Note that the `provider_token` cookie may visibly remain in DevTools — that's expected; what matters is that API calls return 401. |
 | User lands on a junk page after sign-in (e.g. `/.well-known/appspecific/com.chrome.devtools.json`) | Background-fetch URL was captured as `refURL`. The `isNavigationRequest` filter in `GetRefURL` should drop this. |
 
 {{< alert type="info" >}}

--- a/content/en/cloud/identity/authentication/authentication-flows.md
+++ b/content/en/cloud/identity/authentication/authentication-flows.md
@@ -1,0 +1,362 @@
+---
+title: Authentication Flows
+description: >
+  Step-by-step walkthroughs of every sign-in, sign-up, sign-out, and account-management flow Layer5 Cloud supports.
+weight: 1
+categories: [Identity]
+tags: [authentication, oauth, oidc, kratos, hydra, signup, login, logout, recovery, github, google]
+---
+
+This page catalogues every authentication flow Layer5 Cloud exposes to end users. Each flow is described from three perspectives: the user-visible journey, the HTTP / cookie behaviour underneath, and the entry-points and exit-points used by integrators (deep-links, redirect parameters, downstream flows).
+
+## Common architecture
+
+Every authentication action the browser takes is routed through Layer5 Cloud — never directly to Ory Kratos. The hop pattern is the same for every flow:
+
+```
+Browser                Cloud Server                       Kratos
+   │                       │                                │
+   │── GET /login ───────►│                                │
+   │                       │── (no flow? no session?) ────►│
+   │                       │   GET /api/auth/flow/init     │
+   │                       │── CreateBrowserLoginFlow ────►│
+   │                       │◄── flow + Set-Cookie ─────────│
+   │◄─ 302 /login?flow=<id> + Set-Cookie (Path=/) ────────│
+   │                       │                                │
+   │── GET /login?flow=<id> ─►│                            │
+   │◄─ React page ─────────│                                │
+   │                       │                                │
+   │── GET /api/auth/flow?type=login&id=<id> ─►│            │
+   │                       │── GetLoginFlow ─────►│         │
+   │                       │◄── flow JSON ────────│         │
+   │◄─ form action="/api/auth/flow/submit?type=login&id=<id>" │
+   │                       │                                │
+   │── POST /api/auth/flow/submit?type=login&id=<id> ─►│   │
+   │                       │── POST /self-service/login ──►│
+   │                       │◄── 303 Location: <next> ──────│
+   │◄─ 303 Location + Set-Cookie (Path=/) ───────────────│
+```
+
+Three properties hold for **every** flow on this page:
+
+1. **The browser never POSTs to Kratos directly.** The form action is always `/api/auth/flow/submit?type=<flow-type>&id=<flow-id>` on the cloud server.
+2. **The browser never redirects to a Kratos URL.** Every server hop ends at a cloud-server path (`/api/auth/...`).
+3. **Cookies relayed from Kratos are rewritten** so they survive the proxy: the `Domain` attribute is stripped (the cookie binds host-only to the cloud server origin), and `Path` is normalised to `/` so the browser sends them on `/api/auth/flow/submit`. Other attributes — `Name`, `Value`, `MaxAge`, `Expires`, `Secure`, `HttpOnly`, `SameSite` — pass through unchanged.
+
+These invariants are what allow Layer5 Cloud to look like a first-party application even though Kratos and Hydra are doing the heavy lifting under the hood.
+
+### Flow types and the pages they back
+
+The cloud server's flow proxy maps the five Kratos flow types onto the five corresponding pages on Layer5 Cloud:
+
+| Flow type   | Kratos endpoint        | Layer5 Cloud page | Lifespan      |
+|-------------|------------------------|-------------------|---------------|
+| `login`        | `/self-service/login`        | `/login`          | 12 hours       |
+| `registration` | `/self-service/registration` | `/registration`   | 24 hours       |
+| `verification` | `/self-service/verification` | `/verification`   | 30 days        |
+| `recovery`     | `/self-service/recovery`     | `/recovery`       | 30 days        |
+| `settings`     | `/self-service/settings`     | `/reset`          | 24 h privileged window |
+
+The submit-proxy (`/api/auth/flow/submit`) enforces a 1 MiB request-body cap and a 30-second timeout to Kratos. Oversize bodies return `413 Request Entity Too Large`; transport failures to Kratos return `502 Bad Gateway`.
+
+### Cookies set during authentication
+
+| Cookie | Set by | Scope | Lifetime | Purpose |
+|---|---|---|---|---|
+| `session_cookie` | Kratos (relayed) | host-only on cloud-server origin, `Path=/` | 12 h (login session) | Kratos session for the browser; gates `/account` settings access. |
+| `provider_token` | Cloud server (`HandleAuthRedirect`, `HydraCallback`) | `.layer5.io` (eTLD+1) | 24 h | Hydra-issued OAuth2 access token. Read by every cloud-server API handler and forwarded to Meshery clients. |
+| `provider_token` (custom-domain) | Cloud server (`HandleAuthRedirect`) | host-only on the custom domain | 24 h | Second copy of the same token, scoped to the exact custom-domain host so SameSite tightening doesn't drop it. |
+| `Layer5-Current-Orgid` | Cloud server | host-only on whichever domain is being themed | session | Theming hint for the auth pages and a continuity hint across the Kratos handshake. **Not** an authorization signal. |
+| `new_user` | Cloud server (`HandleRegister`) | host-only, `Path=/` | session | Marks a freshly-registered identity so the `/registered` page can show the right onboarding state. Cleared at `HandleAuthRedirect`. |
+| `source_ref` / `return_to` / `meshery_ref` / `_meshery_saas_ref` | Cloud server | host-only | up to 30 minutes | Capture the URL that initiated the auth flow so the user lands back where they started after sign-in. Cleared at `HandleAuthRedirect` / `HydraCallback`. |
+| `anonymousUserID` | Cloud server (during anonymous flow) | host-only | until claimed | Identifies the anonymous identity whose content will be migrated onto the new account at sign-up. |
+
+## Flow inventory
+
+| Flow | Trigger | Pages involved |
+|------|---------|----------------|
+| [Email registration](#email-registration) | `/registration` | `registration` → `registered` → `verification` |
+| [Email verification](#email-verification) | Click on verification email | `verification` (`sent_email` → `passed_challenge`) |
+| [Email login](#email-login) | `/login` | `login` → `dashboard` |
+| [GitHub OAuth signup](#github-oauth-signup) | `/registration` → "Sign up with GitHub" | `registration` → GitHub → `registered` → `dashboard` |
+| [GitHub OAuth login](#github-oauth-login) | `/login` → "Sign in with GitHub" | `login` → GitHub → `dashboard` |
+| [Google OAuth signup](#google-oauth-signup) | `/registration` → "Sign up with Google" | `registration` → Google → `registered` → `dashboard` |
+| [Google OAuth login](#google-oauth-login) | `/login` → "Sign in with Google" | `login` → Google → `dashboard` |
+| [Password recovery](#password-recovery) | `/recovery` | `recovery` → email → `password-reset` |
+| [Password reset](#password-reset) | Click on recovery email | `password-reset` → `login` |
+| [Account settings (link / unlink / change password)](#account-settings-link--unlink--change-password) | `/account` from logged-in profile | `account` → `reset` |
+| [Anonymous handover](#anonymous-handover) | Anonymous user signs up / logs in | `registration?anonymousUserID=<id>` |
+| [Invitation acceptance](#invitation-acceptance) | Click on invitation email | `/invitations/<id>/accept` |
+| [Logout](#logout) | Click "Sign out" in the user menu | `dashboard` → `login` |
+
+---
+
+## Email registration
+
+The user creates a Layer5 Cloud account from scratch using an email address and a password.
+
+**User journey**
+
+1. Navigate to `/registration` (linked from the marketing site or from the "Sign up" toggle on `/login`).
+2. Fill in first name, last name, email, and password. If reCAPTCHA is configured (controlled by the `RECAPTCHA_SITE_KEY` setting), solve the challenge — the **Sign up** button stays disabled until you do.
+3. Submit. You land on `/registered` and Layer5 Cloud sends a verification email. A `new_user=true` cookie is set so the next page can show the right onboarding state.
+4. Open the email, click **Verify**, and you'll be bounced through the [email-verification flow](#email-verification) into `/login`.
+5. Log in with the credentials you just set. You land on `/dashboard`.
+
+**Behaviour notes**
+
+* The form posts to `/api/auth/flow/submit?type=registration&id=<flow-id>`.
+* Validation happens client-side first: name regex (`^[\p{L}\p{M}\s]{1,50}$/u`, accepts unicode letters and marks but no digits or symbols), an RFC-leaning email regex, and a spam filter that blocks listed names and email domains.
+* Password rules are enforced server-side by Kratos: minimum 8 characters, identifier-similarity check (your password may not be substantially similar to your email), and a "have I been pwned" check against the public breach corpus.
+* The reCAPTCHA token, when present, is sent as a hidden input named `transient_payload` with value `{"recaptcha_token":"<token>"}`.
+* The flow lasts 24 hours from creation; expired flows return a fresh one via `/api/auth/flow/init`.
+* If the registration includes an `anonymousUserID` query parameter (see [Anonymous handover](#anonymous-handover)), it survives every flow init and restart so designs created before signup can be claimed afterwards.
+
+---
+
+## Email verification
+
+Verifying an email address is the second half of [email registration](#email-registration), and is also retriggerable from the **Resend verification email** link on `/login`.
+
+**User journey**
+
+1. Open the verification email and click the link. It points at `/verification?flow=<id>` on Layer5 Cloud.
+2. The page server-renders the `passed_challenge` state and immediately redirects you to `/login`.
+3. Sign in normally.
+
+**Behaviour notes**
+
+* Verification flows are valid for 30 days but each `flow=<id>` is single-use. If the link has expired or been used, the cloud server bounces the browser through `/api/auth/flow/init` to mint a fresh flow that asks the user to re-enter their email.
+* For users who registered via OAuth, email verification is implicit — the OAuth provider has already attested the address, so Kratos marks the identity as verified at registration time.
+* The verification flow recipe is `code` (a one-time code embedded in the email link); there is no separate "enter the code" UI.
+
+---
+
+## Email login
+
+The standard sign-in flow for users who registered with an email address and password.
+
+**User journey**
+
+1. Navigate to `/login`.
+2. The page renders helper links — **Forgot password?**, **Resend verification email**, and a **Sign up** toggle for users who don't yet have an account.
+3. Enter your email and password and submit.
+4. On success, Hydra issues an OAuth2 access token. The cloud server sets the `provider_token` cookie (twice — see [Custom domains → Cookie scopes](/cloud/identity/authentication/custom-domains/#cookie-scopes)) and redirects you to your post-login destination.
+
+**Where you land after signing in**
+
+The post-login destination is selected in this order:
+
+1. **`?ref=` query parameter** on the URL that started the auth flow — used by trusted upstream systems (e.g. a Meshery server) to hand off a deep-link.
+2. **`meshery_ref` cookie** set by a Meshery instance acting as a Layer5 Cloud client.
+3. **`return_to` / `source_ref` cookie** captured at the start of the flow from the request URL — but **only** when the original request was a real top-level browser navigation (`Sec-Fetch-Dest: document`, method `GET`, and not a static-asset path or a `/.well-known/...` probe). Background fetches (favicon requests, service-worker probes, the Chrome DevTools `/.well-known/appspecific/com.chrome.devtools.json` probe, XHR, sub-resource loads) are deliberately ignored so they don't poison the post-login destination.
+4. **`/dashboard`** as the default fallback.
+
+The capture step also explicitly skips paths that *are* the auth flow itself (`/login`, `/registration`, `/callback`, `/logout`) so the user can't end up looped back into sign-in after they finish signing in.
+
+**Behaviour notes**
+
+* On invalid password, Kratos returns the existing flow with an error message attached and the user re-renders the same `/login?flow=<id>` page with the message inlined next to the relevant field.
+* On expired flow (HTTP `410 Gone` from Kratos), the cloud server bounces the browser back through `/api/auth/flow/init` to mint a new one — the user sees a fresh `/login` page, never an error.
+* Login flows last 12 hours; this is the maximum time between landing on `/login` and submitting the form.
+* The login flow's `after.password.hooks` configuration includes `require_verified_address`, so a password login submitted before email verification redirects to the verification page rather than completing.
+
+---
+
+## GitHub OAuth signup
+
+Single sign-on registration via GitHub, using OAuth 2.0 / OpenID Connect.
+
+**User journey**
+
+1. Navigate to `/registration`.
+2. Click **Sign up with GitHub**. The button is rendered with `formNoValidate` so HTML5 client-side validation does not block the OAuth submit.
+3. The browser is redirected to GitHub's consent screen. Kratos requests scopes `read:user` and `user:email`, plus the OIDC claims `name`, `profile`, `picture`, `email`, and `email_verified`.
+4. After consent, GitHub redirects back to Layer5 Cloud's OIDC callback (reverse-proxied through the cloud server's `/.ory/...` path). Kratos consumes the callback and creates the identity.
+5. A registration webhook fires server-side, creating the corresponding row in the `users` table and provisioning the user's default workspace.
+6. Hydra issues the access token, the cloud server sets the `provider_token` cookie, and you land on `/registered` (and then `/dashboard`).
+
+**Behaviour notes**
+
+* The button label `Sign up with GitHub` comes directly from Kratos's flow JSON (`flow.ui.nodes[].meta.label.text`). Login flows return "Sign in with GitHub"; registration flows return "Sign up with GitHub".
+* OIDC submits skip the registration page's name/email/spam-filter validation entirely — GitHub supplies those fields, and they're populated server-side after the callback.
+* The user's `provider` field is set to `github` (derived from the OIDC issuer) and their `userId` to the GitHub username.
+
+---
+
+## GitHub OAuth login
+
+Subsequent sign-ins for an account that was either originally registered via GitHub or has had GitHub [linked](#account-settings-link--unlink--change-password) afterwards.
+
+**User journey**
+
+1. Navigate to `/login`.
+2. Click **Sign in with GitHub**.
+3. GitHub consent (skipped if you have an active GitHub session and previously authorized Layer5 Cloud).
+4. Land on `/dashboard` with a valid access token.
+
+**Critical assertion**: after the OIDC round-trip the browser must not see a `401`. If it does, the most likely cause is the cookie `Path` attribute — the cloud server's cookie-relay normalises Kratos's native `Path=/.ory/kratos/public/` to `Path=/`; if that has been bypassed, the next form post will fail CSRF.
+
+---
+
+## Google OAuth signup
+
+Single sign-on registration via Google, using OAuth 2.0 / OpenID Connect.
+
+**User journey**
+
+1. Navigate to `/registration`.
+2. Click **Sign up with Google**.
+3. Google consent. Kratos requests scopes `email` and `profile`, plus the OIDC claims `email`, `email_verified`, and `given_name`.
+4. After consent, Google redirects back through Kratos's OIDC callback.
+5. The same registration webhook as the GitHub flow fires, creating the user record and the default workspace.
+6. Hydra issues the access token, the cloud server sets the `provider_token` cookie, and you land on `/registered` (and then `/dashboard`).
+
+**Behaviour notes**
+
+* The button label `Sign up with Google` is supplied by Kratos's flow JSON.
+* The user's `provider` field is set to `google`; their `userId` is set to the Google account's stable identifier.
+* The `family_name` claim is requested but optional — accounts with no family name will still complete signup.
+
+---
+
+## Google OAuth login
+
+Subsequent sign-ins for an account that was either originally registered via Google or has had Google [linked](#account-settings-link--unlink--change-password) afterwards.
+
+**User journey**
+
+1. Navigate to `/login`.
+2. Click **Sign in with Google**.
+3. Google consent (skipped if you have an active Google session and previously authorized Layer5 Cloud).
+4. Land on `/dashboard` with a valid access token.
+
+---
+
+## Password recovery
+
+Self-service flow for users who have forgotten their password.
+
+**User journey**
+
+1. Click **Forgot password?** on `/login`. You land on `/recovery`.
+2. Enter the email address associated with your account and submit. You see a confirmation screen ("We've sent you a recovery email if an account exists with that address.")
+3. Open the recovery email and click the link. It points to `/password-reset?flow=<id>` (a `code` recipe — the URL contains a one-time code).
+4. Enter and confirm a new password, then submit.
+5. You're redirected to `/login`. Sign in with the new password.
+
+**Behaviour notes**
+
+* The wording at step 2 is intentionally non-committal — the response does not disclose whether the email is registered, to prevent enumeration.
+* Recovery flows are valid for 30 days, but the one-time code in the email link is single-use.
+* A single email may receive multiple recovery requests; only the most recent code remains valid.
+
+---
+
+## Password reset
+
+The second half of [password recovery](#password-recovery), reachable directly via the recovery-email link.
+
+If the link is expired or already-used, the `/password-reset` page detects the `410 Gone` from Kratos and bounces back through `/api/auth/flow/init` to start a fresh recovery flow — the user is asked to re-enter their email address and a new email is sent.
+
+---
+
+## Account settings (link / unlink / change password)
+
+Lets a signed-in user change their password, attach an additional credential method (e.g. add Google to a password-only account), or remove an existing one.
+
+**User journey**
+
+1. Sign in to your account.
+2. Navigate to `/account`. The page surfaces three operations: **change password**, **link provider**, **unlink provider**. The list of currently linked providers is rendered from your Kratos identity.
+3. Pick an operation. Layer5 Cloud calls `/api/auth/flow/init?type=settings`, which returns a settings flow ID that the page submits via `/api/auth/flow/submit?type=settings&id=<flow-id>`.
+4. **Linking a new provider** — provider consent fires (GitHub or Google), and on completion your Kratos identity now carries both credential methods.
+5. **Unlinking a provider** — Kratos validates that you still have at least one usable credential method left. You can never remove the only credential method on the account.
+6. **Changing a password** — Kratos enforces the same minimum-length / leaked-credential rules as the registration flow.
+
+**Behaviour notes**
+
+* The settings flow has a 24-hour `privileged_session_max_age`. If you signed in more than 24 hours ago, Kratos will require a fresh sign-in before allowing destructive changes (set/change password, unlink, etc.).
+* Linking is keyed on the email address Kratos receives from the provider — so if you sign up with `alice@example.com` via password and later try to **sign in** (not link) with a GitHub account whose primary email is `alice@example.com`, you'll be prompted for the existing password and the linking happens automatically. See [User Accounts → Account Linking](/cloud/identity/users/#account-linking) for the full rules.
+* When you delete your Layer5 Cloud account entirely, all linked OAuth providers are automatically unlinked. Re-registering with the same email does **not** automatically re-link previously linked providers; you must re-do the linking flow.
+
+---
+
+## Anonymous handover
+
+Layer5 Cloud lets a visitor create a design, fork a published catalog item, or start a Kanvas snapshot **before** signing up. Behind the scenes the platform mints an anonymous user (an unbound identity) and threads an `anonymousUserID` query parameter through every subsequent navigation. When the visitor decides to sign up, the anonymous content is migrated onto the new account.
+
+**User journey**
+
+1. As an anonymous visitor, create a design. Layer5 Cloud calls `POST /api/identity/users/anonymous` and returns a UUID it stores in a cookie.
+2. The visitor clicks **Sign up**. The link is constructed as `/registration?anonymousUserID=<uuid>`.
+3. Complete [email registration](#email-registration) or [GitHub](#github-oauth-signup) / [Google](#google-oauth-signup) OAuth signup as normal. The `anonymousUserID` parameter survives every redirect — the flow-init proxy explicitly preserves it through Kratos's flow handoff and through the post-auth bounce.
+4. After Hydra issues the access token, `HydraCallback` invokes `MigrateUserResourceToCurrentUser` to reattach the anonymous identity's content (designs, snapshots) to the new account, then deletes the anonymous identity.
+
+**Other parameters that survive flow restarts**
+
+The same allowlist that preserves `anonymousUserID` also carries:
+
+* `login_challenge` — Hydra OAuth2 continuation token. Dropping it would force a fresh OAuth flow and the user would land on `/login` instead of completing the in-progress flow.
+* `refresh=true` — instructs Kratos to enforce re-authentication regardless of the existing session.
+* `return_to` — explicit deep-link to land on after authentication.
+* `program` — used by enrolment flows tied to specific learning programmes.
+* `orgId` — pre-selects an organization context for the auth pages (see [Custom domains](/cloud/identity/authentication/custom-domains)).
+
+---
+
+## Invitation acceptance
+
+Org admins can invite a user to an organization by email, optionally pre-assigning a role and a team. The invitation email points at a URL on the **default domain** (`cloud.layer5.io`) even when the inviting organization has a custom domain — the recipient is not yet a member and therefore cannot be served from the custom domain.
+
+**User journey**
+
+1. The invitee receives an email with an **Accept invitation** link, which points at `/invitations/<inviteId>/accept`.
+2. If the invitee is not signed in, the page first runs the standard [email login](#email-login) (or signs them up via [email registration](#email-registration), [GitHub](#github-oauth-signup), or [Google](#google-oauth-signup) if they don't yet have an account). The flow sets a `Layer5-Current-Orgid` cookie carrying the inviting org's UUID so the auth pages can be themed for that org.
+3. Once signed in, the page calls `POST /api/identity/invitations/<id>/accept`. Layer5 Cloud:
+   * Adds the user to the inviting organization (writes a row to `users_organizations_mappings`).
+   * Assigns the role specified in the invitation, if any.
+   * Adds the user to the team specified in the invitation, if any.
+4. The page sets `selectedOrganizationId = <inviting-org-id>` in the user's preferences.
+5. If the inviting organization has a custom domain, the page redirects the browser to that domain's `/dashboard`. If not, it stays on the default domain. See [Custom domains → Invitation acceptance via email link](/cloud/identity/authentication/custom-domains/#invitation-acceptance-via-email-link) for the full sequence.
+
+---
+
+## Logout
+
+Logout terminates the user's session on Layer5 Cloud and revokes the OAuth2 access token at Hydra so it can't be used to call the API afterwards.
+
+**User journey**
+
+1. Click your avatar in the header and choose **Sign out**.
+2. The browser hits Layer5 Cloud's logout handler. Three things happen in order:
+   * The cloud server calls Hydra's `RevokeToken` endpoint with the current `provider_token`. Hydra invalidates the token; subsequent calls with that token return `401 Unauthorized` even before the cookie expires.
+   * The Kratos session cookie is cleared by sending a `Set-Cookie: <name>=; Max-Age=-1; Path=/`. This terminates the Kratos session that backs the `/account` settings flow.
+   * The `provider_token` cookie is cleared on every domain it was set on (the eTLD+1-scoped copy and the host-scoped copy).
+3. Kratos's `flows.logout.after.default_browser_return_url` is configured to `/login`, so the browser lands on the login page.
+
+**Behaviour notes**
+
+* Logout is a single-page event — the user's browser is the only client invalidated. If you are signed in on a different device, that session is unaffected; revoke it from [Sessions](https://cloud.layer5.io/security/sessions) instead.
+* API tokens (Personal Access Tokens) are not affected by the browser logout. To revoke an API token, see [Tokens](/cloud/security/tokens).
+* If a Meshery instance is using your Layer5 Cloud session, that Meshery instance will receive `401` responses for its next API call and prompt the user to re-authenticate.
+
+---
+
+## Failure modes and diagnostics
+
+| Symptom | First thing to check |
+|---|---|
+| `401 Unauthorized` immediately after an OIDC round-trip | The session cookie set by Kratos must have `Path=/` (so the browser sends it on `/api/auth/flow/submit`). The cloud server's cookie-relay normalises this; if it has been bypassed, you'll see the cookie restricted to `/.ory/...` and the next form post will fail CSRF. |
+| OAuth button does nothing on the registration page | HTML5 form validation is blocking. The OIDC submit button must carry `formNoValidate`. |
+| Form submit fails CSRF on the very first attempt | The `/api/auth/flow/init` response must include the CSRF cookie — check `Set-Cookie` is present and `Path=/`. |
+| `/registration?flow=<id>` redirects to a 404 page | `KRATOS_BROWSER_URL` has been re-exposed to the JavaScript bundle by mistake. The public UI must treat Kratos as if it doesn't exist. |
+| Anonymous designs disappear after signup | Trace `anonymousUserID` through every redirect. It must appear in `/api/auth/flow/init`, in the post-init bounce-back, and in the `source_ref` cookie that the post-auth handler reads to trigger `MigrateUserResourceToCurrentUser`. |
+| `413 Request Entity Too Large` on form submit | Body exceeded the 1 MiB cap on the submit proxy. Legitimate flows do not approach this; investigate what is being submitted. |
+| Form submit hangs | The cloud server enforces a 30-second timeout to Kratos. A hang past this point indicates Kratos itself is slow or unreachable. |
+| Logout button "did nothing" — user is still signed in | Check both `provider_token` cookies (eTLD+1-scoped and host-scoped, on custom domains). Both must be cleared. |
+| User lands on a junk page after sign-in (e.g. `/.well-known/appspecific/com.chrome.devtools.json`) | Background-fetch URL was captured as `refURL`. The `isNavigationRequest` filter in `GetRefURL` should drop this. |
+
+{{< alert type="info" >}}
+For background on how the access tokens issued at the end of these flows are used, see [Tokens](/cloud/security/tokens) and [Sessions](/cloud/security/sessions). For how the same flows behave when a user belongs to an organization with a custom domain, see [Custom domains](/cloud/identity/authentication/custom-domains).
+{{< /alert >}}

--- a/content/en/cloud/identity/authentication/custom-domains.md
+++ b/content/en/cloud/identity/authentication/custom-domains.md
@@ -11,6 +11,17 @@ Layer5 Cloud lets a tenant organization map its own hostname (e.g. `academy.laye
 
 If you haven't already, read [Authentication Flows](/cloud/identity/authentication/authentication-flows) first. This page builds on those flows.
 
+## Worked example: the Academy organization
+
+The scenarios on this page use one consistent worked example throughout:
+
+* **Org name:** Academy
+* **Org id (variable):** `academy_org`
+* **Custom domain:** `academy.layer5.io`
+* **Default domain:** `cloud.layer5.io` (the platform's `SERVER_BASE_URL`)
+
+Wherever you see `academy_org` in pseudo-code, that's the UUID of the Academy organization. Wherever you see `academy.layer5.io`, that's the custom domain mapped to it. Substitute your own org's name and hostname when reading.
+
 ## The contract in one paragraph
 
 > The custom-domain hostname is the strongest **scope** signal — it pins every request to a specific tenant for read/write authorization. The user's preference is the strongest **intent** signal — it answers "what organization does the user want to be looking at right now". When intent and scope conflict, the system **changes the scope** (redirects the URL/domain), not the intent (the preference). Switching the preference to match a wrong scope is always a bug.
@@ -49,7 +60,7 @@ Custom-domain registration is performed by Provider Admins via the org-managemen
 
 ## The six sources of organization context
 
-A request can carry organization context from any of six places. Each has a different lifetime and a different trust level. The server normalises them into a single `CurrentOrgID` value on the request context; the UI runs a parallel resolution.
+A request can carry organization context from any of six places. Each has a different lifetime and a different trust level. The server normalizes them into a single `CurrentOrgID` value on the request context; the UI runs a parallel resolution.
 
 | # | Source | Wire shape | Lifetime | Set by | Trust |
 |---|--------|------------|----------|--------|-------|
@@ -104,10 +115,10 @@ The codebase passes around what looks like a UUID, but four out of those five va
 | A real UUID | A specific organization | DB `organizations.id`, `users.preferences.selectedOrganizationId`, route params, cookie |
 | `"all"` | "All organizations" view, only valid for **provider admins** | UI Redux/preference, server query string |
 | `"11111111-1111-1111-1111-111111111111"` | Provider organization sentinel — alias for "all" | Server context; UI organization utility |
-| `""` (empty string) | "Unknown / not set yet" — the resolver should fall through to fallbacks, not error | Cookie present-but-empty, prefs key cleared by canonicalising migration |
+| `""` (empty string) | "Unknown / not set yet" — the resolver should fall through to fallbacks, not error | Cookie present-but-empty, prefs key cleared by canonicalizing migration |
 | `nil` / undefined | Same as `""`. Code paths must handle both | DB `organizations.domain`, JSON optionals |
 
-The Provider Org UUID and the string `"all"` are **interchangeable on the wire**. The server normalises one to the other on persistence, and the UI normalises the other direction on read. Empty string is never a valid org id; always treat it as "unknown" and fall through.
+The Provider Org UUID and the string `"all"` are **interchangeable on the wire**. The server normalizes one to the other on persistence, and the UI normalizes the other direction on read. Empty string is never a valid org id; always treat it as "unknown" and fall through.
 
 ---
 
@@ -126,27 +137,29 @@ http.SetCookie(res, &http.Cookie{
 // Second — host-scoped on the actual request host
 http.SetCookie(res, &http.Cookie{
     Name:   "provider_token",
-    Domain: "exoscale.layer5.io",         // AccessTokenCookieForCustomDomain(req)
+    Domain: "academy.layer5.io",          // AccessTokenCookieForCustomDomain(req)
     Path:   "/",
     Value:  token,                        // (same value)
 })
 ```
 
-The first is **parent-scoped**: a `Domain` of `.layer5.io` means the cookie is sent on *every* `*.layer5.io` request, which is what makes a `cloud.layer5.io` → `exoscale.layer5.io` redirect carry the user's session. The second is **host-scoped**: when the auth completes on the custom domain itself, an extra cookie scoped to that exact host is set so future SameSite tightening doesn't drop it.
+The first is **parent-scoped**: a `Domain` of `.layer5.io` means the cookie is sent on *every* `*.layer5.io` request, which is what makes a `cloud.layer5.io` → `academy.layer5.io` redirect carry the user's session. The second is **host-scoped**: when the auth completes on the custom domain itself, an extra cookie scoped to that exact host is set so future SameSite tightening doesn't drop it.
 
 ### Implications
 
 * **Custom domains that are subdomains of `*.layer5.io`** receive both cookies via `window.location.href` redirects; no special handshake is needed.
 * **Custom domains on a different eTLD** (e.g. `cloud.meshery.io`) cannot receive the parent-scoped cookie because eTLD+1 doesn't match. The platform supports them via the **token-handoff redirect** described below.
-* The parent-scoped cookie means *any* `*.layer5.io` site that is also on this Hydra/Kratos session can read it. That's intentional (e.g. kanvas.new flows), but worth knowing.
+* The parent-scoped cookie means *any* `*.layer5.io` site that is also on this Hydra/Kratos session can read it. That's intentional (e.g. Kanvas at `kanvas.new` flows), but worth knowing.
 
 ### The token-handoff redirect (cross-eTLD bridge)
 
-For cross-eTLD domains, Layer5 Cloud uses `RedirectWithTokenToCustomOrgdomain` to bridge the cookie:
+For cross-eTLD domains, Layer5 Cloud uses `RedirectWithTokenToCustomOrgdomain` to bridge the cookie. Reading top-down with the user as the active subject:
 
-1. After Hydra completes login on `cloud.layer5.io`, `issueSessionForOtherDomains` builds a redirect URL that bounces through the destination domain so it can set its own cookie. The originating host is threaded through the OAuth2 `state` payload as `origin_host`.
-2. The destination calls back to `/auth/redirect/accept` on the original domain with the token. The handler reads the `origin_host` query parameter, validates the value against the `custom_domains` registry (open-redirect guard), then forwards through `RedirectWithTokenToCustomOrgdomain` if the host belongs to a registered tenant.
-3. `HandleAuthRedirect` is the symmetric endpoint — it accepts a `?token=` query, sets the cookie on both `.layer5.io` and the current host, and finally redirects to either the original referrer or the org's custom domain. Pre-`origin_host` invocations fall back to the legacy `Layer5-Current-Orgid` cookie path.
+1. After Hydra completes login on `cloud.layer5.io`, `issueSessionForOtherDomains` redirects the browser to a `kanvas.new/auth/redirect` URL whose `return_to` parameter points back at `cloud.layer5.io/auth/redirect/accept`. The originating host is also threaded along as `origin_host` (encoded into the OAuth2 `state` payload Hydra round-tripped earlier).
+2. The browser is redirected back to `/auth/redirect/accept` on `cloud.layer5.io` with the token. The handler reads the `origin_host` query parameter, validates the value against the `custom_domains` registry (open-redirect guard), and — when the host belongs to a registered tenant — forwards the browser to the destination domain's `/auth/redirect/accept` endpoint via `RedirectWithTokenToCustomOrgdomain`.
+3. The destination domain's `HandleAuthRedirect` accepts the `?token=` query, sets the `provider_token` cookie host-only on that domain, and finally redirects to either the original referrer or the destination's `/dashboard`.
+
+A misconfigured `origin_host` (e.g. a host not in the registry) causes the cross-domain hop to be skipped and the legacy `Layer5-Current-Orgid` cookie path to take over. A warning is logged so the misconfiguration surfaces in operations.
 
 This handshake is **not** used for in-session navigation between same-eTLD subdomains. The plain `window.location.href = ...` pattern works there precisely because the parent-scoped cookie carries the session.
 
@@ -154,7 +167,7 @@ This handshake is **not** used for in-session navigation between same-eTLD subdo
 
 ## End-to-end scenarios
 
-The eight scenarios below cover every combination of "where is the user" and "what is the user's preference". The first column tells you what to expect; the second is the contract; the third is what happens under the hood.
+The eight scenarios below cover every combination of "where is the user" and "what is the user's preference". Each one uses the Academy worked example introduced at the top of this page.
 
 ### Scenario 1 — Default domain, default-domain org
 
@@ -180,18 +193,18 @@ This is the simplest case. There's no scope/intent conflict to reconcile.
 
 ### Scenario 2 — Default domain, custom-domain org
 
-> User logs in on `cloud.layer5.io`. Their preferred org is `Orbital Labs`, which is mapped to `exoscale.layer5.io`.
+> User logs in on `cloud.layer5.io`. Their preferred org is **Academy**, which is mapped to `academy.layer5.io`.
 
-The user authenticates as in Scenario 1, but on the post-auth dashboard render the client detects that `selectedOrganization.domain = exoscale.layer5.io` and the current hostname is `cloud.layer5.io`. The contract says: **change scope to match intent**.
+The user authenticates as in Scenario 1, but on the post-auth dashboard render the client detects that `selectedOrganization.domain = academy.layer5.io` and the current hostname is `cloud.layer5.io`. The contract says: **change scope to match intent**.
 
 ```
 Browser → /dashboard on cloud.layer5.io   (post-login)
    useGetSelectedOrganization → selectedOrganization = academy_org (with domain)
    Effect P3: selectedOrganization.domain non-empty
               → SyncBrowserUrlWithOrgDomain(selectedOrganization)
-              → window.location.href = "https://exoscale.layer5.io/dashboard"
+              → window.location.href = "https://academy.layer5.io/dashboard"
 
-Browser → /dashboard on exoscale.layer5.io
+Browser → /dashboard on academy.layer5.io
    New page load. CustomDomainOrgResolverMiddleware sets CurrentOrgID = academy_org.id
    useGetSelectedOrganization → selectedOrganization = academy_org
    Effect P2: hostname matches academy_org.domain, IDs match → steady state.
@@ -201,15 +214,15 @@ The `provider_token` parent-scoped cookie carries the session across the redirec
 
 ### Scenario 3 — Custom domain, member of that org
 
-> User signs in on `exoscale.layer5.io` and is a member of the `Orbital Labs` org that owns it.
+> User signs in on `academy.layer5.io` and is a member of the **Academy** org that owns it.
 
 ```
-Browser → /login on exoscale.layer5.io
+Browser → /login on academy.layer5.io
    Server: CustomDomainOrgResolverMiddleware → CurrentOrgID = academy_org.id
-           (auth pages are themed with academy branding via buildOrgAuthData)
+           (auth pages are themed with Academy branding via buildOrgAuthData)
    Kratos flow → Hydra issues token
-   Server sets provider_token cookie on .layer5.io AND on exoscale.layer5.io
-   Browser → /dashboard on exoscale.layer5.io
+   Server sets provider_token cookie on .layer5.io AND on academy.layer5.io
+   Browser → /dashboard on academy.layer5.io
    Effect P2: hostname matches selected, IDs match → steady state.
 ```
 
@@ -217,7 +230,7 @@ This is the steady-state custom-domain experience — the user logs in directly 
 
 ### Scenario 4 — Custom domain, **not** a member
 
-> Visitor lands on `exoscale.layer5.io` but is not a member of `Orbital Labs`.
+> Visitor lands on `academy.layer5.io` but is not a member of the **Academy** org.
 
 The contract is: **surface the authorization error**, do not silently redirect. The custom-domain resolver still pins `CurrentOrgID = academy_org.id`, but the per-handler authorization check (every DAO call carries a `userID` and filters by `users_organizations_mappings`) rejects the request. The UI shows a real "you don't have access to this organization" page rather than bouncing the user back to the default domain.
 
@@ -225,26 +238,26 @@ This is intentional: a silent bounce would mask a misconfiguration (e.g. an invi
 
 ### Scenario 5 — Switching org via the header switcher
 
-> Authenticated user picks a different org from the header dropdown.
+> Authenticated user picks the **Academy** org from the header dropdown.
 
 ```
-User picks "Academy Org" from header switcher
-   onClick → useUpdateSelectedOrganization.handleUpdate(academyOrgId)
+User picks "Academy" from header switcher
+   onClick → useUpdateSelectedOrganization.handleUpdate(academy_org.id)
        1. invalidate organizations cache and refetch
-       2. validate academyOrgId is in the refetched list
+       2. validate academy_org.id is in the refetched list
           (refuses to switch to an org the user isn't a member of)
-       3. PUT /api/identity/users/preferences  (selectedOrganizationId = academyOrgId)
+       3. PUT /api/identity/users/preferences  (selectedOrganizationId = academy_org.id)
           Server: UpdateUserPreference → "Saved user … preferences"
        4. SyncBrowserUrlWithOrgDomain(academy_org)
-          → window.location.href = "https://exoscale.layer5.io/<current-path>"
-   exoscale.layer5.io page load → P2 steady state (same as Scenario 3 tail).
+          → window.location.href = "https://academy.layer5.io/<current-path>"
+   academy.layer5.io page load → P2 steady state (same as Scenario 3 tail).
 ```
 
 The persistence (PUT preferences) happens **before** the redirect, so by the time the new domain loads, the DB row already matches what the user picked. If the new org has no custom domain, step 4 redirects to the default domain instead.
 
 ### Scenario 6 — Academy enrolment with a custom domain
 
-> User is on `cloud.layer5.io/academy/<academyOrgId>/learning-path/<slug>`, **not yet a member** of `academyOrgId`. They click **Enroll Now**.
+> User is on `cloud.layer5.io/academy/<academy_org.id>/learning-path/<slug>`, **not yet a member** of the Academy org. They click **Enroll Now**.
 
 ```
 Click "Enroll Now"
@@ -254,29 +267,29 @@ Click "Enroll Now"
           create academy_registration row
           if curricula.InviteId != nil:
               InvitationService.AcceptInvitation(user, curricula.InviteId)
-                AddUserToOrganization(user.ID, academy_org.ID)   ← user becomes member
+                AddUserToOrganization(user.ID, academy_org.id)   ← user becomes member
                 AssignRoleToUserInOrg(...)
                 AddUserToTeam(...)
           return 200 OK
-  → updateSelectedOrg(curricula.org_id)         ← academy_org.ID
+  → updateSelectedOrg(curricula.org_id)         ← academy_org.id
         PUT /api/identity/users/preferences
         SyncBrowserUrlWithOrgDomain(academy_org)
-  → window.location.href = "https://exoscale.layer5.io/academy/<academyOrgId>/learning-path/<slug>"
+  → window.location.href = "https://academy.layer5.io/academy/<academy_org.id>/learning-path/<slug>"
 
-exoscale.layer5.io page load:
-  CustomDomainOrgResolverMiddleware → CurrentOrgID = academy_org.ID
+academy.layer5.io page load:
+  CustomDomainOrgResolverMiddleware → CurrentOrgID = academy_org.id
   Queries:
-     getUser → preferences.selectedOrganizationId = academy_org.ID  ✓
+     getUser → preferences.selectedOrganizationId = academy_org.id  ✓
      getOrgs → must include academy_org (membership was just written)
   useGetSelectedOrganization → selectedOrganization = academy_org
   P2: hostname matches → steady state.
 ```
 
-The membership write **must** complete before the redirect; otherwise the post-redirect page-load on the custom domain sees `getOrgs` returning a list that doesn't include the academy org and the user lands in the unauth state covered by Scenario 4.
+The membership write **must** complete before the redirect; otherwise the post-redirect page-load on the custom domain sees `getOrgs` returning a list that doesn't include the Academy org and the user lands in the unauth state covered by Scenario 4.
 
 ### Scenario 7 — Invitation acceptance via email link
 
-> User clicks an **Accept invitation** link from an email. The inviting org (`Orbital Labs`) has a custom domain (`exoscale.layer5.io`), but the email link points at `cloud.layer5.io`.
+> User clicks an **Accept invitation** link from an email. The inviting org is **Academy** (custom domain `academy.layer5.io`), but the email link points at `cloud.layer5.io`.
 
 The email link is on the default domain because the invitee is **not yet a member** and therefore can't be served from the custom domain.
 
@@ -286,24 +299,24 @@ Email link → /invitations/<inviteId>/accept on cloud.layer5.io
      useAcceptInvitationMutation()  → POST /api/identity/invitations/<id>/accept
         Server: write users_organizations_mappings row
                 assign role / team if specified
-                set Layer5-Current-Orgid cookie = inviteOrg.id
+                set Layer5-Current-Orgid cookie = academy_org.id
                                          (host-only on cloud.layer5.io,
                                           carries org context through Kratos handshake
                                           if user needs to authenticate first)
      await updateSelectedOrg(acceptedInvite.orgId)
                                        PUT preferences
-     SyncBrowserUrlWithOrgDomain(inviteOrg)
-                                       → exoscale.layer5.io/dashboard
-  exoscale.layer5.io: P2 steady state.
+     SyncBrowserUrlWithOrgDomain(academy_org)
+                                       → academy.layer5.io/dashboard
+  academy.layer5.io: P2 steady state.
 ```
 
-If the invitee was not signed in when they clicked the link, the auth chain runs first ([email login](/cloud/identity/authentication/authentication-flows/#email-login), or one of the OAuth flows). The `Layer5-Current-Orgid` cookie set during the invitation-accept request is what themes the auth pages with the inviting org's branding.
+If the invitee was not signed in when they clicked the link, the auth chain runs first ([email login](/cloud/identity/authentication/authentication-flows/#email-login), or one of the OAuth flows). The `Layer5-Current-Orgid` cookie set during the invitation-accept request is what themes the auth pages with the Academy org's branding.
 
 ### Scenario 8 — Cross-eTLD custom domain (e.g. `cloud.meshery.io`)
 
 > Tenant org has a custom domain on a different eTLD than the platform — e.g. `cloud.meshery.io` rather than `*.layer5.io`. The parent-scoped cookie can't follow.
 
-This is the case the **token-handoff redirect** exists for. The user authenticates on `cloud.layer5.io` (or the cross-eTLD host directly); the cloud server threads the originating host through the OAuth2 `state` as `origin_host`, and `HandleAuthRedirect` validates that host against the `custom_domains` registry before issuing `RedirectWithTokenToCustomOrgdomain`. The destination calls back to `/auth/redirect/accept` with the token; the handler sets the `provider_token` cookie host-only on the cross-eTLD host, then redirects to the original referrer or the dashboard.
+This is the case the **token-handoff redirect** exists for. The user authenticates on `cloud.layer5.io`; the cloud server threads the originating host through the OAuth2 `state` as `origin_host`, and after the Hydra round-trip `HandleAuthRedirect` validates that host against the `custom_domains` registry before issuing `RedirectWithTokenToCustomOrgdomain`. The destination domain's `/auth/redirect/accept` then sets the `provider_token` cookie host-only on the cross-eTLD host and redirects to the original referrer or the destination's dashboard.
 
 A misconfigured `origin_host` (e.g. a host not in the registry) causes the bridge to be skipped and the legacy `Layer5-Current-Orgid` cookie path to take over. A warning is logged so the misconfiguration surfaces in operations.
 
@@ -316,12 +329,12 @@ A misconfigured `origin_host` (e.g. a host not in the registry) causes the bridg
 ```
 Browser              Ingress               Cloud server                  DB
    │                    │                       │                         │
-   │  GET /api/orgs     │  Host: exoscale...    │                         │
+   │  GET /api/orgs     │  Host: academy...     │                         │
    │ ───────────────►   │ ────────────────────► │                         │
    │                    │                       │ CustomDomainOrgResolver │
    │                    │                       │ → GetOrganizationByDomain
    │                    │                       │ ──────────────────────► │
-   │                    │                       │ ctx.CurrentOrgID = academy_org_id
+   │                    │                       │ ctx.CurrentOrgID = academy_org.id
    │                    │                       │                         │
    │                    │                       │ OrganizationResolver: short-circuit
    │                    │                       │                         │
@@ -333,7 +346,7 @@ Browser              Ingress               Cloud server                  DB
 ### Org switch with a domain hop
 
 ```
-Browser            cloud.layer5.io            exoscale.layer5.io
+Browser            cloud.layer5.io            academy.layer5.io
    │                    │                          │
    │ click switcher     │                          │
    │                    │                          │
@@ -343,8 +356,8 @@ Browser            cloud.layer5.io            exoscale.layer5.io
    │ getOrgs (refetch) ►│                          │
    │ ◄──── 200 ──────── │                          │
    │                    │                          │
-   │ window.location.href = exoscale.layer5.io/...
-   │ ─────────────────────────────────────────────►│
+   │ window.location.href = academy.layer5.io/...
+   │ ──────────────────────────────────────────────►│
    │                                               │
    │                        page load              │
    │                        getUser, getOrgs ─────►│
@@ -387,9 +400,9 @@ There are exactly four code paths that write `users.preferences.selectedOrganiza
 
 | Caller | Trigger | Notes |
 |---|---|---|
-| `UpdateUserPreference` handler | `PUT /api/identity/users/preferences` from UI | Normalises `"all"` → `PROVIDER_ORG_ID` before persisting. |
+| `UpdateUserPreference` handler | `PUT /api/identity/users/preferences` from UI | Normalizes `"all"` → `PROVIDER_ORG_ID` before persisting. |
 | `useUpdateSelectedOrganization` (UI) | Org switcher, academy enrol, invitation accept | Calls the handler above; persistence completes before `SyncBrowserUrlWithOrgDomain` triggers the redirect. |
-| `OrganizationSessionProvider` priorities | Page-load reconciliation | Writes only when the URL explicitly asked for a different org, or when canonicalising preference to a domain-pinned org the user is a member of. |
+| `OrganizationSessionProvider` priorities | Page-load reconciliation | Writes only when the URL explicitly asked for a different org, or when canonicalizing preference to a domain-pinned org the user is a member of. |
 | Historical migration | One-shot | Removes invalid pre-canonical preference values (empty string, JSON null, malformed UUID). |
 
 The `Layer5-Current-Orgid` cookie is written by the start of the Kratos auth flow and the invitation acceptance redirect. **It is not** a session-scoped cookie that follows the user around — treat it as a hint for theming and Kratos flow continuity, not as a source of truth for authorization scope.
@@ -398,7 +411,7 @@ The `Layer5-Current-Orgid` cookie is written by the start of the Kratos auth flo
 
 ## Cross-organization access
 
-Users of one organization may be granted access to resources (workspaces, designs) in another organization, but **entitlements are org-scoped**: the permissions a user has in `Orbital Labs` do not automatically apply in `Stellar Dynamics`, and vice versa. When a user with cross-org access switches to a different org via the header switcher, they will be redirected to the matching custom domain (Scenario 5) — or stay on the default domain if the destination org has no custom domain.
+Users of one organization may be granted access to resources (workspaces, designs) in another organization, but **entitlements are org-scoped**: the permissions a user has in one org do not automatically apply in another, and vice versa. When a user with cross-org access switches to a different org via the header switcher, they will be redirected to the matching custom domain (Scenario 5) — or stay on the default domain if the destination org has no custom domain.
 
 See [Identity → Organizations](/cloud/identity/organizations) for cross-organization access controls and the example tenant structure (`Constellation Cloud` → `Orbital Labs` / `Stellar Dynamics`).
 

--- a/content/en/cloud/identity/authentication/custom-domains.md
+++ b/content/en/cloud/identity/authentication/custom-domains.md
@@ -1,0 +1,419 @@
+---
+title: Custom Domains
+description: >
+  How Layer5 Cloud authenticates and routes traffic when a tenant organization is mapped to its own hostname.
+weight: 2
+categories: [Identity]
+tags: [authentication, custom-domains, multi-tenancy, organizations]
+---
+
+Layer5 Cloud lets a tenant organization map its own hostname (e.g. `academy.layer5.io`, `exoscale.layer5.io`, or even a non-Layer5-eTLD like `cloud.meshery.io`) so that members of that organization can sign in and work entirely on a domain that is branded for them. This page documents how authentication and request routing behave once a custom domain is in play, and the full set of scenarios that arise when a user's preferred organization differs from the domain they're currently on.
+
+If you haven't already, read [Authentication Flows](/cloud/identity/authentication/authentication-flows) first. This page builds on those flows.
+
+## The contract in one paragraph
+
+> The custom-domain hostname is the strongest **scope** signal — it pins every request to a specific tenant for read/write authorization. The user's preference is the strongest **intent** signal — it answers "what organization does the user want to be looking at right now". When intent and scope conflict, the system **changes the scope** (redirects the URL/domain), not the intent (the preference). Switching the preference to match a wrong scope is always a bug.
+
+## Two related but distinct concepts
+
+| Concept | Meaning | Source of truth |
+|---|---|---|
+| **Acting org** (scope) | The organization context for the current request — what the server reads from and writes to. | The hostname (custom domain), or the `Layer5-Current-Orgid` header / cookie / preference fallback. |
+| **Selected org** (intent) | The organization the user *wants* to be looking at. | `users.preferences.selectedOrganizationId` in the user's profile. |
+
+The custom-domain feature is the place where these two concepts pull hardest in different directions, because the URL the user is on and the preference the user has set can disagree. Everything else on this page is a consequence of how the platform reconciles the two.
+
+---
+
+## What counts as a custom domain
+
+A hostname is a custom domain if **all** of the following hold:
+
+1. It is not the configured default `SERVER_BASE_URL` (e.g. `cloud.layer5.io`).
+2. It is not in the `ReservedDomains` list. The reserved set covers Layer5's own infrastructure hostnames so an attacker can't register them as a tenant. The current reserved domains are:
+
+   ```
+   cloud.layer5.io           cloud-ws.layer5.io        cloud-staging.layer5.io
+   cloud-dev.layer5.io       test.layer5.io            meshery.layer5.io
+   meshery-staging.layer5.io dev.layer5.io             staging.layer5.io
+   layer5.io                 docs.layer5.io
+   ```
+
+3. It is not a raw IP address (those resolve to health-check probes, not tenants).
+4. It resolves to a row in the `organizations` table whose `domain` column matches.
+
+Custom-domain registration is performed by Provider Admins via the org-management UI; the `IsCustomDomain` server-side check is what gates every middleware on this page.
+
+---
+
+## The six sources of organization context
+
+A request can carry organization context from any of six places. Each has a different lifetime and a different trust level. The server normalises them into a single `CurrentOrgID` value on the request context; the UI runs a parallel resolution.
+
+| # | Source | Wire shape | Lifetime | Set by | Trust |
+|---|--------|------------|----------|--------|-------|
+| 1 | URL **path** param `/api/identity/orgs/:orgId/...` | path segment | per-request | route definition | server enforces — must match user-membership |
+| 2 | URL **query** param `?orgId=...` (read) or `?currentOrgId=...` (UI nav) | query string | per-request | client | server enforces |
+| 3 | `Layer5-Current-Orgid` request **header** | HTTP header | per-request | client | server treats as *suggested* — falls back if invalid |
+| 4 | `Layer5-Current-Orgid` **cookie** | Set-Cookie, no Domain → host-only | session-ish | server during Kratos flow / invitation accept | server *suggested*; cookie is dropped on cross-domain redirect |
+| 5 | **Custom-domain hostname** (`req.Host`) | the request URL itself | the user's whole session on that domain | DNS + ingress + DB `organizations.domain` | **strongest scope signal** — server pins context unconditionally |
+| 6 | `users.preferences.selectedOrganizationId` (DB) | JSONB column on `users` | persistent until user changes it | UI mutation `PUT /api/identity/users/preferences` | trusted intent signal |
+
+### Server-side precedence
+
+Implemented in `server/handlers/middlewares_authz_scope.go`:
+
+```text
+CustomDomainOrgResolverMiddleware       (source 5)
+        ↓ if no custom-domain match
+OrganizationResolverMiddleware
+   ├─ already-set short-circuit         (source 5 wins)
+   ├─ Layer5-Current-Orgid cookie       (source 4)
+   ├─ Layer5-Current-Orgid header       (source 3)
+   ├─ user.preferences                  (source 6)
+   └─ "all" only if provider admin
+```
+
+Path/query params (sources 1 and 2) are handled by *route-specific* middlewares that override `OrgID` for the targeted route. They don't influence `CurrentOrgID`; they coexist.
+
+### Client-side precedence
+
+Implemented in `OrganizationSessionProvider`:
+
+```text
+?currentOrgId=… in URL                   (source 2)
+        ↓
+visiting a custom domain                 (source 5)
+        ↓
+user.preferences.selectedOrganizationId  (source 6)
+        ↓
+fallback: first active org
+```
+
+Note the *asymmetry*: the server's strongest signal (custom domain) is matched on the client by a URL-driven branch — but only because the page is loaded on that hostname. Server and client must agree on what counts as a "custom domain", which is why both consult the same `IsCustomDomain` check.
+
+---
+
+## Special identifier values
+
+The codebase passes around what looks like a UUID, but four out of those five values are actually *sentinels*:
+
+| Value | Meaning | Where it appears |
+|---|---|---|
+| A real UUID | A specific organization | DB `organizations.id`, `users.preferences.selectedOrganizationId`, route params, cookie |
+| `"all"` | "All organizations" view, only valid for **provider admins** | UI Redux/preference, server query string |
+| `"11111111-1111-1111-1111-111111111111"` | Provider organization sentinel — alias for "all" | Server context; UI organization utility |
+| `""` (empty string) | "Unknown / not set yet" — the resolver should fall through to fallbacks, not error | Cookie present-but-empty, prefs key cleared by canonicalising migration |
+| `nil` / undefined | Same as `""`. Code paths must handle both | DB `organizations.domain`, JSON optionals |
+
+The Provider Org UUID and the string `"all"` are **interchangeable on the wire**. The server normalises one to the other on persistence, and the UI normalises the other direction on read. Empty string is never a valid org id; always treat it as "unknown" and fall through.
+
+---
+
+## Cookie scopes
+
+When a user authenticates on Layer5 Cloud, two `provider_token` cookies are set on every successful sign-in:
+
+```go
+// First — parent-scoped on eTLD+1
+http.SetCookie(res, &http.Cookie{
+    Name:   "provider_token",
+    Domain: ".layer5.io",                 // AccessTokenCookieDomain()
+    Path:   "/",
+    Value:  token,
+})
+// Second — host-scoped on the actual request host
+http.SetCookie(res, &http.Cookie{
+    Name:   "provider_token",
+    Domain: "exoscale.layer5.io",         // AccessTokenCookieForCustomDomain(req)
+    Path:   "/",
+    Value:  token,                        // (same value)
+})
+```
+
+The first is **parent-scoped**: a `Domain` of `.layer5.io` means the cookie is sent on *every* `*.layer5.io` request, which is what makes a `cloud.layer5.io` → `exoscale.layer5.io` redirect carry the user's session. The second is **host-scoped**: when the auth completes on the custom domain itself, an extra cookie scoped to that exact host is set so future SameSite tightening doesn't drop it.
+
+### Implications
+
+* **Custom domains that are subdomains of `*.layer5.io`** receive both cookies via `window.location.href` redirects; no special handshake is needed.
+* **Custom domains on a different eTLD** (e.g. `cloud.meshery.io`) cannot receive the parent-scoped cookie because eTLD+1 doesn't match. The platform supports them via the **token-handoff redirect** described below.
+* The parent-scoped cookie means *any* `*.layer5.io` site that is also on this Hydra/Kratos session can read it. That's intentional (e.g. kanvas.new flows), but worth knowing.
+
+### The token-handoff redirect (cross-eTLD bridge)
+
+For cross-eTLD domains, Layer5 Cloud uses `RedirectWithTokenToCustomOrgdomain` to bridge the cookie:
+
+1. After Hydra completes login on `cloud.layer5.io`, `issueSessionForOtherDomains` builds a redirect URL that bounces through the destination domain so it can set its own cookie. The originating host is threaded through the OAuth2 `state` payload as `origin_host`.
+2. The destination calls back to `/auth/redirect/accept` on the original domain with the token. The handler reads the `origin_host` query parameter, validates the value against the `custom_domains` registry (open-redirect guard), then forwards through `RedirectWithTokenToCustomOrgdomain` if the host belongs to a registered tenant.
+3. `HandleAuthRedirect` is the symmetric endpoint — it accepts a `?token=` query, sets the cookie on both `.layer5.io` and the current host, and finally redirects to either the original referrer or the org's custom domain. Pre-`origin_host` invocations fall back to the legacy `Layer5-Current-Orgid` cookie path.
+
+This handshake is **not** used for in-session navigation between same-eTLD subdomains. The plain `window.location.href = ...` pattern works there precisely because the parent-scoped cookie carries the session.
+
+---
+
+## End-to-end scenarios
+
+The eight scenarios below cover every combination of "where is the user" and "what is the user's preference". The first column tells you what to expect; the second is the contract; the third is what happens under the hood.
+
+### Scenario 1 — Default domain, default-domain org
+
+> User logs in on `cloud.layer5.io`. Their preferred org has no custom domain.
+
+```
+Browser → /login on cloud.layer5.io
+   Kratos flow → Hydra issues token
+   Server sets provider_token cookie on .layer5.io
+   Server → 302 to /dashboard (preserves ref)
+   Browser → GET /dashboard on cloud.layer5.io
+     _app.js mounts OrganizationSessionProvider
+     Queries: getUser, getOrgs
+     useGetSelectedOrganization → selectedOrganization = user's default org (no custom domain)
+     Effect:
+       P1 (?currentOrgId): no   → skip
+       P2 (custom domain): no   → skip
+       P3 (selected has domain): no → skip
+       Steady state.
+```
+
+This is the simplest case. There's no scope/intent conflict to reconcile.
+
+### Scenario 2 — Default domain, custom-domain org
+
+> User logs in on `cloud.layer5.io`. Their preferred org is `Orbital Labs`, which is mapped to `exoscale.layer5.io`.
+
+The user authenticates as in Scenario 1, but on the post-auth dashboard render the client detects that `selectedOrganization.domain = exoscale.layer5.io` and the current hostname is `cloud.layer5.io`. The contract says: **change scope to match intent**.
+
+```
+Browser → /dashboard on cloud.layer5.io   (post-login)
+   useGetSelectedOrganization → selectedOrganization = academy_org (with domain)
+   Effect P3: selectedOrganization.domain non-empty
+              → SyncBrowserUrlWithOrgDomain(selectedOrganization)
+              → window.location.href = "https://exoscale.layer5.io/dashboard"
+
+Browser → /dashboard on exoscale.layer5.io
+   New page load. CustomDomainOrgResolverMiddleware sets CurrentOrgID = academy_org.id
+   useGetSelectedOrganization → selectedOrganization = academy_org
+   Effect P2: hostname matches academy_org.domain, IDs match → steady state.
+```
+
+The `provider_token` parent-scoped cookie carries the session across the redirect. The user is signed in by the time the dashboard loads on the custom domain.
+
+### Scenario 3 — Custom domain, member of that org
+
+> User signs in on `exoscale.layer5.io` and is a member of the `Orbital Labs` org that owns it.
+
+```
+Browser → /login on exoscale.layer5.io
+   Server: CustomDomainOrgResolverMiddleware → CurrentOrgID = academy_org.id
+           (auth pages are themed with academy branding via buildOrgAuthData)
+   Kratos flow → Hydra issues token
+   Server sets provider_token cookie on .layer5.io AND on exoscale.layer5.io
+   Browser → /dashboard on exoscale.layer5.io
+   Effect P2: hostname matches selected, IDs match → steady state.
+```
+
+This is the steady-state custom-domain experience — the user logs in directly on the tenant hostname and never sees the default domain.
+
+### Scenario 4 — Custom domain, **not** a member
+
+> Visitor lands on `exoscale.layer5.io` but is not a member of `Orbital Labs`.
+
+The contract is: **surface the authorization error**, do not silently redirect. The custom-domain resolver still pins `CurrentOrgID = academy_org.id`, but the per-handler authorization check (every DAO call carries a `userID` and filters by `users_organizations_mappings`) rejects the request. The UI shows a real "you don't have access to this organization" page rather than bouncing the user back to the default domain.
+
+This is intentional: a silent bounce would mask a misconfiguration (e.g. an invitation link that was accepted under the wrong account, or a stale custom-domain registration).
+
+### Scenario 5 — Switching org via the header switcher
+
+> Authenticated user picks a different org from the header dropdown.
+
+```
+User picks "Academy Org" from header switcher
+   onClick → useUpdateSelectedOrganization.handleUpdate(academyOrgId)
+       1. invalidate organizations cache and refetch
+       2. validate academyOrgId is in the refetched list
+          (refuses to switch to an org the user isn't a member of)
+       3. PUT /api/identity/users/preferences  (selectedOrganizationId = academyOrgId)
+          Server: UpdateUserPreference → "Saved user … preferences"
+       4. SyncBrowserUrlWithOrgDomain(academy_org)
+          → window.location.href = "https://exoscale.layer5.io/<current-path>"
+   exoscale.layer5.io page load → P2 steady state (same as Scenario 3 tail).
+```
+
+The persistence (PUT preferences) happens **before** the redirect, so by the time the new domain loads, the DB row already matches what the user picked. If the new org has no custom domain, step 4 redirects to the default domain instead.
+
+### Scenario 6 — Academy enrolment with a custom domain
+
+> User is on `cloud.layer5.io/academy/<academyOrgId>/learning-path/<slug>`, **not yet a member** of `academyOrgId`. They click **Enroll Now**.
+
+```
+Click "Enroll Now"
+  → registerToContent({ contentId, … })
+        Server: POST /api/academy/register
+          orgId = <user's currently-selected org>   (the *acting* org, not the academy org)
+          create academy_registration row
+          if curricula.InviteId != nil:
+              InvitationService.AcceptInvitation(user, curricula.InviteId)
+                AddUserToOrganization(user.ID, academy_org.ID)   ← user becomes member
+                AssignRoleToUserInOrg(...)
+                AddUserToTeam(...)
+          return 200 OK
+  → updateSelectedOrg(curricula.org_id)         ← academy_org.ID
+        PUT /api/identity/users/preferences
+        SyncBrowserUrlWithOrgDomain(academy_org)
+  → window.location.href = "https://exoscale.layer5.io/academy/<academyOrgId>/learning-path/<slug>"
+
+exoscale.layer5.io page load:
+  CustomDomainOrgResolverMiddleware → CurrentOrgID = academy_org.ID
+  Queries:
+     getUser → preferences.selectedOrganizationId = academy_org.ID  ✓
+     getOrgs → must include academy_org (membership was just written)
+  useGetSelectedOrganization → selectedOrganization = academy_org
+  P2: hostname matches → steady state.
+```
+
+The membership write **must** complete before the redirect; otherwise the post-redirect page-load on the custom domain sees `getOrgs` returning a list that doesn't include the academy org and the user lands in the unauth state covered by Scenario 4.
+
+### Scenario 7 — Invitation acceptance via email link
+
+> User clicks an **Accept invitation** link from an email. The inviting org (`Orbital Labs`) has a custom domain (`exoscale.layer5.io`), but the email link points at `cloud.layer5.io`.
+
+The email link is on the default domain because the invitee is **not yet a member** and therefore can't be served from the custom domain.
+
+```
+Email link → /invitations/<inviteId>/accept on cloud.layer5.io
+  /accept page:
+     useAcceptInvitationMutation()  → POST /api/identity/invitations/<id>/accept
+        Server: write users_organizations_mappings row
+                assign role / team if specified
+                set Layer5-Current-Orgid cookie = inviteOrg.id
+                                         (host-only on cloud.layer5.io,
+                                          carries org context through Kratos handshake
+                                          if user needs to authenticate first)
+     await updateSelectedOrg(acceptedInvite.orgId)
+                                       PUT preferences
+     SyncBrowserUrlWithOrgDomain(inviteOrg)
+                                       → exoscale.layer5.io/dashboard
+  exoscale.layer5.io: P2 steady state.
+```
+
+If the invitee was not signed in when they clicked the link, the auth chain runs first ([email login](/cloud/identity/authentication/authentication-flows/#email-login), or one of the OAuth flows). The `Layer5-Current-Orgid` cookie set during the invitation-accept request is what themes the auth pages with the inviting org's branding.
+
+### Scenario 8 — Cross-eTLD custom domain (e.g. `cloud.meshery.io`)
+
+> Tenant org has a custom domain on a different eTLD than the platform — e.g. `cloud.meshery.io` rather than `*.layer5.io`. The parent-scoped cookie can't follow.
+
+This is the case the **token-handoff redirect** exists for. The user authenticates on `cloud.layer5.io` (or the cross-eTLD host directly); the cloud server threads the originating host through the OAuth2 `state` as `origin_host`, and `HandleAuthRedirect` validates that host against the `custom_domains` registry before issuing `RedirectWithTokenToCustomOrgdomain`. The destination calls back to `/auth/redirect/accept` with the token; the handler sets the `provider_token` cookie host-only on the cross-eTLD host, then redirects to the original referrer or the dashboard.
+
+A misconfigured `origin_host` (e.g. a host not in the registry) causes the bridge to be skipped and the legacy `Layer5-Current-Orgid` cookie path to take over. A warning is logged so the misconfiguration surfaces in operations.
+
+---
+
+## Sequence diagrams
+
+### Steady-state read on a custom domain
+
+```
+Browser              Ingress               Cloud server                  DB
+   │                    │                       │                         │
+   │  GET /api/orgs     │  Host: exoscale...    │                         │
+   │ ───────────────►   │ ────────────────────► │                         │
+   │                    │                       │ CustomDomainOrgResolver │
+   │                    │                       │ → GetOrganizationByDomain
+   │                    │                       │ ──────────────────────► │
+   │                    │                       │ ctx.CurrentOrgID = academy_org_id
+   │                    │                       │                         │
+   │                    │                       │ OrganizationResolver: short-circuit
+   │                    │                       │                         │
+   │                    │                       │ Handler: GetOrganizations(userID)
+   │                    │                       │ ──────────────────────► │
+   │ ◄───────────────── │ ◄──────────────────── │ 200 OK                  │
+```
+
+### Org switch with a domain hop
+
+```
+Browser            cloud.layer5.io            exoscale.layer5.io
+   │                    │                          │
+   │ click switcher     │                          │
+   │                    │                          │
+   │ PUT /preferences ─►│                          │
+   │ ◄────── 201 ────── │                          │
+   │                    │                          │
+   │ getOrgs (refetch) ►│                          │
+   │ ◄──── 200 ──────── │                          │
+   │                    │                          │
+   │ window.location.href = exoscale.layer5.io/...
+   │ ─────────────────────────────────────────────►│
+   │                                               │
+   │                        page load              │
+   │                        getUser, getOrgs ─────►│
+   │                        ◄────────────────── 200│
+   │                        P2 steady state        │
+```
+
+### Cross-eTLD token handoff
+
+```
+Browser              cloud.layer5.io              cloud.meshery.io
+   │                      │                            │
+   │ OIDC complete on cloud.layer5.io                  │
+   │ ◄──────────────────── │ provider_token cookie set │
+   │                       │ on .layer5.io             │
+   │                       │                           │
+   │ HydraCallback decodes state.origin_host = cloud.meshery.io
+   │ issueSessionForOtherDomains → 302 to /auth/redirect/accept
+   │ ◄──────────────────── │                           │
+   │                       │                           │
+   │ /auth/redirect/accept on cloud.layer5.io          │
+   │ validates origin_host against custom_domains      │
+   │ RedirectWithTokenToCustomOrgdomain → 303          │
+   │ ──────────────────────────────────────────────────►
+   │                                                   │
+   │           cloud.meshery.io/auth/redirect/accept   │
+   │           sets provider_token host-only            │
+   │           302 → /dashboard                        │
+   │ ◄─────────────────────────────────────────────────│
+   │                                                   │
+   │           dashboard on cloud.meshery.io           │
+   │ ──────────────────────────────────────────────────►
+```
+
+---
+
+## Persistence — writes to `selectedOrganizationId`
+
+There are exactly four code paths that write `users.preferences.selectedOrganizationId`:
+
+| Caller | Trigger | Notes |
+|---|---|---|
+| `UpdateUserPreference` handler | `PUT /api/identity/users/preferences` from UI | Normalises `"all"` → `PROVIDER_ORG_ID` before persisting. |
+| `useUpdateSelectedOrganization` (UI) | Org switcher, academy enrol, invitation accept | Calls the handler above; persistence completes before `SyncBrowserUrlWithOrgDomain` triggers the redirect. |
+| `OrganizationSessionProvider` priorities | Page-load reconciliation | Writes only when the URL explicitly asked for a different org, or when canonicalising preference to a domain-pinned org the user is a member of. |
+| Historical migration | One-shot | Removes invalid pre-canonical preference values (empty string, JSON null, malformed UUID). |
+
+The `Layer5-Current-Orgid` cookie is written by the start of the Kratos auth flow and the invitation acceptance redirect. **It is not** a session-scoped cookie that follows the user around — treat it as a hint for theming and Kratos flow continuity, not as a source of truth for authorization scope.
+
+---
+
+## Cross-organization access
+
+Users of one organization may be granted access to resources (workspaces, designs) in another organization, but **entitlements are org-scoped**: the permissions a user has in `Orbital Labs` do not automatically apply in `Stellar Dynamics`, and vice versa. When a user with cross-org access switches to a different org via the header switcher, they will be redirected to the matching custom domain (Scenario 5) — or stay on the default domain if the destination org has no custom domain.
+
+See [Identity → Organizations](/cloud/identity/organizations) for cross-organization access controls and the example tenant structure (`Constellation Cloud` → `Orbital Labs` / `Stellar Dynamics`).
+
+---
+
+## Glossary
+
+* **Default domain** — the value of `SERVER_BASE_URL` (e.g. `cloud.layer5.io`). The platform's canonical entry point.
+* **Custom domain** — any hostname that resolves through `IsCustomDomain` to an org with `organizations.domain` set, *and* is not in `ReservedDomains`.
+* **Acting org** — the org context for the current request as derived by the server middlewares (`CurrentOrgID`).
+* **Selected org** — the user's persisted preference (`users.preferences.selectedOrganizationId`).
+* **Provider org** — the synthetic org with id `11111111-1111-1111-1111-111111111111`, used as the parent / fallback context for provider admins. Synonymous with `"all"` on the wire.
+* **Membership** — a non-deleted row in `users_organizations_mappings` for `(user_id, organization_id)`.
+* **Run-once page-load reconciliation** — `OrganizationSessionProvider`'s effect that aligns selected org and current domain at most once per full page load.
+
+{{< alert type="info" >}}
+For the underlying authentication mechanics that get a user signed in to a custom-domain org, see [Authentication Flows](/cloud/identity/authentication/authentication-flows). For the role-based access control that gates what a user can do once they're scoped to an org, see [Roles](/cloud/security/roles).
+{{< /alert >}}

--- a/content/en/cloud/identity/authentication/custom-domains.md
+++ b/content/en/cloud/identity/authentication/custom-domains.md
@@ -255,7 +255,7 @@ User picks "Academy" from header switcher
 
 The persistence (PUT preferences) happens **before** the redirect, so by the time the new domain loads, the DB row already matches what the user picked. If the new org has no custom domain, step 4 redirects to the default domain instead.
 
-### Scenario 6 — Academy enrolment with a custom domain
+### Scenario 6 — Academy enrollment with a custom domain
 
 > User is on `cloud.layer5.io/academy/<academy_org.id>/learning-path/<slug>`, **not yet a member** of the Academy org. They click **Enroll Now**.
 


### PR DESCRIPTION
## Summary

Adds a new **Authentication** section under `cloud/identity/authentication/` that comprehensively documents how Layer5 Cloud handles identity authentication, including the eleven user-facing flows and the eight scenarios that arise once a tenant organization is mapped to a custom domain.

The pages were drafted by reading the Cloud Server source (`server/handlers/auth_flow.go`, `auth.go`, `sessions.go`, `domain_routing/domain_registry.go`), the Kratos configuration (`install/environment/development/kratos.yml`), and the project-internal design notes in `meshery-cloud/docs/auth-flows.md` and `meshery-cloud/docs/organization-id-and-domain-resolution.md`. Every cookie name, OAuth scope, flow lifespan, and redirect path was cross-checked against code before being included.

## Files added

- `content/en/cloud/identity/authentication/_index.md` — landing page; introduces the Cloud Server / Kratos / Hydra split, the scope-vs-intent distinction, and lists supported sign-in providers.
- `content/en/cloud/identity/authentication/authentication-flows.md` — step-by-step walkthrough of every flow:
  - Email registration, email verification, email login
  - GitHub OAuth (signup, login)
  - Google OAuth (signup, login)
  - Password recovery and password reset
  - Account settings (link/unlink providers, change password)
  - Anonymous-user handover
  - Invitation acceptance
  - Logout
  - Plus a cookie inventory, flow-lifespan table, post-login destination resolution rules, and a failure-mode/diagnostics matrix.
- `content/en/cloud/identity/authentication/custom-domains.md` — comprehensive coverage of multi-tenant custom-domain routing:
  - The six sources of organization context (path, query, header, cookie, hostname, preference) with server- and client-side precedence rules
  - The `IsCustomDomain` criteria, including the `ReservedDomains` list
  - Cookie scopes (eTLD+1 parent-scoped + host-scoped) and the cross-eTLD token-handoff bridge for non-`*.layer5.io` domains
  - Eight end-to-end scenarios covering every combination of acting-org and selected-org, including academy enrolment, invitation acceptance via email, org switching, cross-org access, and non-member access to a custom domain
  - Sequence diagrams for steady-state reads, org switching, and the cross-eTLD handoff
  - Glossary

## Test plan

- [ ] `make site` builds without Hugo errors
- [ ] Internal links resolve (`/cloud/identity/authentication`, `/cloud/identity/authentication/authentication-flows`, `/cloud/identity/authentication/custom-domains`, plus cross-references into `/cloud/security/sessions`, `/cloud/security/tokens`, `/cloud/identity/users`, `/cloud/identity/organizations`)
- [ ] New section appears under **Cloud → Identity → Authentication** in the rendered nav at the expected weight (`4` after Users)
- [ ] Page rendering matches the existing identity/security style (frontmatter, `{{< alert >}}` shortcodes, tables)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgSQvpTAu3R9kjCMkm6e4B)_