### PR TITLE
ci: migrate Hugo languageName config to label

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 # THIS IS A TEST CONFIG ONLY!
 # FOR THE CONFIGURATION OF YOUR SITE USE hugo.yaml.
 #
-# As of Docsy 0.7.0, Hugo 0.110.0 or later must be used.
+# As of Docsy 0.7.0, Hugo 0.112.0 or later must be used.
 #
 # The sole purpose of this config file is to detect Hugo-module builds that use
 # an older version of Hugo.
@@ -12,4 +12,4 @@
 module:
   hugoVersion:
     extended: true
-    min: 0.110.0
+    min: 0.112.0

--- a/hugo.toml
+++ b/hugo.toml
@@ -64,7 +64,7 @@ id = "G-HX135VWX9B"
 
 [languages]
 [languages.en]
-languageName = "English"
+label = "English"
 # Weight used for sorting.
 weight = 1
 direction = "ltr"
@@ -328,7 +328,7 @@ enable = false
   # replacements = "github.com/google/docsy -> ../../docsy"
   [module.hugoVersion]
     extended = true
-    min = "0.110.0"
+    min = "0.112.0"
   [[module.imports]]
     path = "github.com/google/docsy"
     disable = false


### PR DESCRIPTION
## Description

Fixes #1030

* Replaced deprecated `languages.en.languageName` with `languages.en.label`
* Updated the minimum Hugo version requirement to `0.112.0`
* Removes the Hugo v0.158.0 deprecation warning during `make site`

## Validation

* Attempted to run `make site`, but `make` is not installed in the local Windows environment
* Verified the repository-pinned Hugo binary is v0.158.0
* Attempted equivalent Hugo commands; they no longer emit the `languages.en.languageName` deprecation warning before stopping on missing `go` for Hugo module loading
