### PR TITLE
[UI] Fix Resources dropdown requiring double click on Cloud and Kanvas pages

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -224,12 +224,16 @@
     event.stopPropagation();
 
     // hide any other active dropdowns
-    const allActiveDropdowns = document.querySelectorAll(".nav-link.current");
+    // Added [data-toggle='dropdown'] so it ignores active page links like #cloud or #kanvas
+    const allActiveDropdowns = document.querySelectorAll(".nav-link.current[data-toggle='dropdown']");
     allActiveDropdowns.forEach((otherDropdown) => {
       if (otherDropdown !== dropdown) {
         otherDropdown.classList.remove("current");
-        otherDropdown.nextElementSibling.classList.remove("show");
-        otherDropdown.nextElementSibling.style.visibility = "hidden"; 
+        // Added a safety check to ensure the nextElementSibling actually exists before modifying it
+        if (otherDropdown.nextElementSibling) {
+            otherDropdown.nextElementSibling.classList.remove("show");
+            otherDropdown.nextElementSibling.style.visibility = "hidden"; 
+        }
       }
     });
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -229,31 +229,32 @@
     allActiveDropdowns.forEach((otherDropdown) => {
       if (otherDropdown !== dropdown) {
         otherDropdown.classList.remove("current");
-const menu = otherDropdown.nextElementSibling;
-if (menu) {
-    menu.classList.remove("show");
-    menu.style.visibility = "hidden";
-}
-      }
-    });
-
-    if (dropdown.classList.contains("current")) {
-        dropdown.classList.remove("current");
-        dropdownMenu.classList.remove("show");
-        dropdownMenu.style.visibility = "hidden"; 
-    } else {
-    dropdown.classList.toggle("current");
-    dropdownMenu.classList.toggle("show");
-    dropdownMenu.style.visibility = "visible"; 
-    }
-  });
-
-    document.body.addEventListener('click', function() {
-      if (dropdown.classList.contains("current")) {
-        dropdown.classList.remove("current");
-        dropdownMenu.classList.remove("show");
-        dropdownMenu.style.visibility = "hidden"; 
-    }
+            const menu = otherDropdown.nextElementSibling;
+            if (menu) {
+                menu.classList.remove("show");
+                menu.style.visibility = "hidden";
+            }
+          }
+        });
+    
+        if (dropdown.classList.contains("current")) {
+            dropdown.classList.remove("current");
+            dropdownMenu.classList.remove("show");
+            dropdownMenu.style.visibility = "hidden"; 
+        } 
+        else {
+            dropdown.classList.toggle("current");
+            dropdownMenu.classList.toggle("show");
+            dropdownMenu.style.visibility = "visible"; 
+        }
+      });
+    
+      document.body.addEventListener('click', function() {
+          if (dropdown.classList.contains("current")) {
+            dropdown.classList.remove("current");
+            dropdownMenu.classList.remove("show");
+            dropdownMenu.style.visibility = "hidden"; 
+        }
   });
 }
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -229,11 +229,11 @@
     allActiveDropdowns.forEach((otherDropdown) => {
       if (otherDropdown !== dropdown) {
         otherDropdown.classList.remove("current");
-        // Added a safety check to ensure the nextElementSibling actually exists before modifying it
-        if (otherDropdown.nextElementSibling) {
-            otherDropdown.nextElementSibling.classList.remove("show");
-            otherDropdown.nextElementSibling.style.visibility = "hidden"; 
-        }
+const menu = otherDropdown.nextElementSibling;
+if (menu) {
+    menu.classList.remove("show");
+    menu.style.visibility = "hidden";
+}
       }
     });
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1026 

The Issue:
The setupDropdown function was querying for all elements with the .current class to close any open menus. On the Cloud/Kanvas pages, the active page link also carries the .current class but does not have a sibling dropdown menu. This caused otherDropdown.nextElementSibling to return null, throwing a TypeError when the script tried to access .classList. This error halted JavaScript execution during the first click, preventing the Resources menu from toggling.

The Fix:

- Updated the selector in setupDropdown to querySelectorAll(".nav-link.current[data-toggle='dropdown']"). This ensures the script only attempts to close actual dropdown menus and ignores active page indicators.

- Added a null check (if (otherDropdown.nextElementSibling)) as a safety measure to prevent future script crashes if the DOM structure varies.

- This fix ensures consistent single-click behavior across the Home, Cloud, and Kanvas pages.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
