### PR TITLE
fix(ui): consolidate double glow effect in kanvas pop-up

### DIFF
--- a/assets/scss/_kanvas-corner-popup.scss
+++ b/assets/scss/_kanvas-corner-popup.scss
@@ -57,7 +57,7 @@
   padding: 1rem;
   border: 1px solid #00d3a9;
   border-radius: 5%;
-  box-shadow: 0 0 42px rgba(0, 211, 169, 0.85), 0 0 80px rgba(0, 211, 169, 0.25);
+  box-shadow: 0 0 28px rgba(0, 211, 169, 0.55);
 
   @media (max-width: 640px) {
     padding: 0.8rem;

--- a/assets/scss/_kanvas-corner-popup.scss
+++ b/assets/scss/_kanvas-corner-popup.scss
@@ -57,7 +57,7 @@
   padding: 1rem;
   border: 1px solid #00d3a9;
   border-radius: 5%;
-  box-shadow: 0 0 28px rgba(0, 211, 169, 0.55);
+  box-shadow: 0 0 28px rgba($secondary, 0.55);
 
   @media (max-width: 640px) {
     padding: 0.8rem;


### PR DESCRIPTION
## Description

This PR fixes the excessive bottom glow effect in the Kanvas popup by refining the `box-shadow` styling.

### Changes Made
- Reduced the intensity of the popup glow effect.
- Consolidated the visual appearance of the bottom border/glow to create a cleaner UI.
- Preserved the existing neon aesthetic while improving visual consistency.

Fixes #1035




**Notes for Reviewers**
- The popup styling was adjusted only for visual refinement.
- No functional changes were introduced.




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.