### PR TITLE
fix: add duration and tags missing

### DIFF
--- a/content/en/videos/advanced/advanced/birth-of-kanvas-logo.md
+++ b/content/en/videos/advanced/advanced/birth-of-kanvas-logo.md
@@ -6,6 +6,8 @@ videoType: youtube  # or "local"
 muted: true  # optional
 autoplay: true  # optional
 loop: true #optional
+tags: [kanvas]
+duration: "0:16"
 ---
 
 {{< youtube id=4WcofErPTx4 class="yt-embed-container" >}}

--- a/content/en/videos/features/meshery/meshery-teaser.md
+++ b/content/en/videos/features/meshery/meshery-teaser.md
@@ -6,5 +6,7 @@ videoType: youtube  # or "local"
 muted: true  # optional
 autoplay: true  # optional
 loop: true #optional
+tags: [meshery]
+duration: "0:53"
 ---
 {{< youtube id=Do7htKrRzDA class="yt-embed-container" >}}

--- a/content/en/videos/getting-started/comments/publish-design.md
+++ b/content/en/videos/getting-started/comments/publish-design.md
@@ -10,7 +10,7 @@ loop: true #optional
 categories: [Designer]
 formats: [video]
 tags: [catalog, designs, publishing]
-duraiton: 0:39
+duration: "0:39"
 ---
 
 {{< youtube id=UCKS4eSB7AY class="yt-embed-container" >}}


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1048 by normalizing video metadata so duration/tags render consistently across cards.
Adds/updates duration and tags for Publishing Designs, Meshery Playground Teaser, and Birth of Kanvas Logo entries.


https://github.com/user-attachments/assets/66fc8c5e-8f45-4eb4-b0ca-f0c6a485b162




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
