### PR TITLE
fix(search): eliminate duplicate searchbar

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -162,7 +162,7 @@ navbar_translucent_over_cover_disable = false
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = true
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-sidebar_search_disable = false
+sidebar_search_disable = true
 # Enable to show toggle arrows
 sidebar_menu_foldable = false
 # Limit the number of levels deep the menu displays


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1057
It eliminates the duplicate search field by disabling the sidebar search, keeping only the top navbar search. Sidebar content now fills the available space from the top. Users can access search using the navbar search bar or by pressing “/” to quickly focus the search.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
