### PR TITLE
fix: remove extra background around search icon on focus

### DIFF
--- a/assets/scss/_search_project.scss
+++ b/assets/scss/_search_project.scss
@@ -95,7 +95,6 @@
     .td-search__icon {
       display: flex;
       color: $input-placeholder-color;
-      background-color: var(--bs-body-bg);
       padding-right: 0.2rem;      
     }
   }


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1017
It removes the unwanted focus background around the search icon.

Before:
<img width="200" height="100" alt="image" src="https://github.com/user-attachments/assets/b2973e74-87c5-4786-99cb-683dce1cd77f" />

After:
<img width="200" height="100" alt="image" src="https://github.com/user-attachments/assets/5889b05d-133f-4337-a814-e23e70f43468" />


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

