### PR TITLE
fix(videos): remove hardcoded min suffix from durations

### DIFF
--- a/content/en/videos/integrations/aws/meshery-teaser.md
+++ b/content/en/videos/integrations/aws/meshery-teaser.md
@@ -7,6 +7,6 @@ muted: true  # optional
 autoplay: true  # optional
 loop: true #optional
 tags: [meshery]
-duration: "2:10"
+duration: "0:53"
 ---
 {{< youtube id=Do7htKrRzDA class="yt-embed-container" >}}

--- a/layouts/partials/video-landing-page.html
+++ b/layouts/partials/video-landing-page.html
@@ -86,7 +86,7 @@
                       {{ if .Params.duration }}
                       <div class="video-duration">
                       <i class="bi bi-clock"></i>
-                      <p class="video-duration" style="display: inline; margin-left: .25rem;">{{ .Params.duration }} min</p>
+                      <p class="video-duration" style="display: inline; margin-left: .25rem;">{{ .Params.duration }}</p>
                       </div>
                       {{ end }}
                       {{ if .Params.tags }}
@@ -137,7 +137,7 @@
                       {{ if .Params.duration }}
                       <div class="video-duration">
                       <i class="bi bi-clock"></i>
-                      <p class="video-duration" style="display: inline; margin-left: .25rem;">{{ .Params.duration }} min</p>
+                      <p class="video-duration" style="display: inline; margin-left: .25rem;">{{ .Params.duration }}</p>
                       </div>
                       {{ end }}
                       {{ if .Params.tags }}

--- a/layouts/partials/video-landing-page.html
+++ b/layouts/partials/video-landing-page.html
@@ -86,7 +86,7 @@
                       {{ if .Params.duration }}
                       <div class="video-duration">
                       <i class="bi bi-clock"></i>
-                      <p class="video-duration" style="display: inline; margin-left: .25rem;">{{ .Params.duration }}</p>
+                      <span style="margin-left: .25rem;">{{ .Params.duration }}</span>
                       </div>
                       {{ end }}
                       {{ if .Params.tags }}
@@ -137,7 +137,7 @@
                       {{ if .Params.duration }}
                       <div class="video-duration">
                       <i class="bi bi-clock"></i>
-                      <p class="video-duration" style="display: inline; margin-left: .25rem;">{{ .Params.duration }}</p>
+                      <span style="margin-left: .25rem;">{{ .Params.duration }}</span>
                       </div>
                       {{ end }}
                       {{ if .Params.tags }}


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1052
<img width="1204" height="732" alt="image" src="https://github.com/user-attachments/assets/72c11d72-55ce-4026-a7cb-03983a5d250d" />


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
