### PR TITLE
Add related reading

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -147,6 +147,9 @@ offlineSearch = true
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false
 
+[params.relatedReading]
+pageTypes = ["docs"]
+
 # User interface configuration
 [params.ui]
 #  Set to true to disable breadcrumb navigation.

--- a/hugo.toml
+++ b/hugo.toml
@@ -23,6 +23,16 @@ enableGitInfo = true
 tag = "tags"
 category = "categories"
 
+[related]
+threshold = 1
+includeNewer = true
+[[related.indices]]
+name = "tags"
+weight = 100
+[[related.indices]]
+name = "categories"
+weight = 200
+
 [params.taxonomy]
 # set taxonomyCloud = [] to hide taxonomy clouds
 taxonomyCloud = ["tags", "categories"]

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -24,6 +24,7 @@
    
    {{ partial "pager.html" . }}
    {{ partial "page-meta-lastmod.html" . -}}
+   {{ partial "related-reading.html" . -}}
    {{ partial "video-section-related.html" . -}}
    {{ partial "recent-discussions.html" . -}}
 </div>

--- a/layouts/docs/rest-apis.html
+++ b/layouts/docs/rest-apis.html
@@ -21,6 +21,7 @@
   {{ partial "page-meta-lastmod.html" . }}
 </div>
 
+{{ partial "related-reading.html" . -}}
 {{ partial "video-section-related.html" . -}}
 <div style="margin-top: 2rem;">
   {{ partial "recent-discussions.html" . -}}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
 {{ .Render "content" }}
-  
+
+{{ partial "related-reading.html" . -}}
 {{ partial "video-section-related.html" . -}}
 <div style="margin-top: 2rem;">
 {{ partial "recent-discussions.html" . -}}

--- a/layouts/partials/related-reading.html
+++ b/layouts/partials/related-reading.html
@@ -1,13 +1,10 @@
-{{ $currentPage := .Page }}
-{{ $currentTags := .Params.tags | default (slice) }}
-{{ $currentCategories := .Params.categories | default (slice) }}
 {{ $limit := 6 }}
 
 {{ $relatedReadingConfig := .Site.Params.relatedReading | default dict }}
 {{ $pageTypes := $relatedReadingConfig.pageTypes | default (slice) }}
 {{ $sections := $relatedReadingConfig.sections | default (slice) }}
 
-{{ $readingPages := .Site.RegularPages }}
+{{ $readingPages := .Site.RegularPages.Related . }}
 {{ if gt (len $pageTypes) 0 }}
   {{ $readingPages = where $readingPages "Type" "in" $pageTypes }}
 {{ end }}
@@ -15,40 +12,39 @@
   {{ $readingPages = where $readingPages "Section" "in" $sections }}
 {{ end }}
 {{ $readingPages = where $readingPages ".Params.videoId" "==" nil }}
-{{ $matchingPages := slice }}
+{{ $relatedPages := first $limit $readingPages }}
 
-{{ range $readingPages }}
-  {{ $page := . }}
-  {{ $matchScore := 0 }}
-
-  {{ if ne $page.RelPermalink $currentPage.RelPermalink }}
-    {{ range $currentTags }}
-      {{ if in ($page.Params.tags | default (slice)) . }}
-        {{ $matchScore = add $matchScore 1 }}
-      {{ end }}
-    {{ end }}
-
-    {{ range $currentCategories }}
-      {{ if in ($page.Params.categories | default (slice)) . }}
-        {{ $matchScore = add $matchScore 2 }}
-      {{ end }}
-    {{ end }}
-
-    {{ if gt $matchScore 0 }}
-      {{ $matchingPages = $matchingPages | append (dict "page" $page "score" $matchScore) }}
+{{ if eq (len $relatedPages) 0 }}
+  {{ $taxonomyPages := slice }}
+  {{ range (.Params.categories | default (slice)) }}
+    {{ with index site.Taxonomies.categories . }}
+      {{ $taxonomyPages = $taxonomyPages | append .Pages }}
     {{ end }}
   {{ end }}
-{{ end }}
+  {{ range (.Params.tags | default (slice)) }}
+    {{ with index site.Taxonomies.tags . }}
+      {{ $taxonomyPages = $taxonomyPages | append .Pages }}
+    {{ end }}
+  {{ end }}
 
-{{ $relatedPages := first $limit (sort $matchingPages "score" "desc") }}
+  {{ $readingPages = uniq $taxonomyPages }}
+  {{ $readingPages = where $readingPages "RelPermalink" "!=" .RelPermalink }}
+  {{ if gt (len $pageTypes) 0 }}
+    {{ $readingPages = where $readingPages "Type" "in" $pageTypes }}
+  {{ end }}
+  {{ if gt (len $sections) 0 }}
+    {{ $readingPages = where $readingPages "Section" "in" $sections }}
+  {{ end }}
+  {{ $readingPages = where $readingPages ".Params.videoId" "==" nil }}
+  {{ $relatedPages = first $limit $readingPages }}
+{{ end }}
 
 {{ if gt (len $relatedPages) 0 }}
 <h2>Related Reading</h2>
 <ul>
   {{ range $relatedPages }}
-    {{ $page := .page }}
     <li style="line-height:1.75rem;padding:0.3rem 0.4rem;">
-      <a href="{{ $page.RelPermalink }}">{{ $page.Title }}</a>
+      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
     </li>
   {{ end }}
 </ul>

--- a/layouts/partials/related-reading.html
+++ b/layouts/partials/related-reading.html
@@ -1,0 +1,55 @@
+{{ $currentPage := .Page }}
+{{ $currentTags := .Params.tags | default (slice) }}
+{{ $currentCategories := .Params.categories | default (slice) }}
+{{ $limit := 6 }}
+
+{{ $relatedReadingConfig := .Site.Params.relatedReading | default dict }}
+{{ $pageTypes := $relatedReadingConfig.pageTypes | default (slice) }}
+{{ $sections := $relatedReadingConfig.sections | default (slice) }}
+
+{{ $readingPages := .Site.RegularPages }}
+{{ if gt (len $pageTypes) 0 }}
+  {{ $readingPages = where $readingPages "Type" "in" $pageTypes }}
+{{ end }}
+{{ if gt (len $sections) 0 }}
+  {{ $readingPages = where $readingPages "Section" "in" $sections }}
+{{ end }}
+{{ $readingPages = where $readingPages ".Params.videoId" "==" nil }}
+{{ $matchingPages := slice }}
+
+{{ range $readingPages }}
+  {{ $page := . }}
+  {{ $matchScore := 0 }}
+
+  {{ if ne $page.RelPermalink $currentPage.RelPermalink }}
+    {{ range $currentTags }}
+      {{ if in ($page.Params.tags | default (slice)) . }}
+        {{ $matchScore = add $matchScore 1 }}
+      {{ end }}
+    {{ end }}
+
+    {{ range $currentCategories }}
+      {{ if in ($page.Params.categories | default (slice)) . }}
+        {{ $matchScore = add $matchScore 2 }}
+      {{ end }}
+    {{ end }}
+
+    {{ if gt $matchScore 0 }}
+      {{ $matchingPages = $matchingPages | append (dict "page" $page "score" $matchScore) }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $relatedPages := first $limit (sort $matchingPages "score" "desc") }}
+
+{{ if gt (len $relatedPages) 0 }}
+<h2>Related Reading</h2>
+<ul>
+  {{ range $relatedPages }}
+    {{ $page := .page }}
+    <li style="line-height:1.75rem;padding:0.3rem 0.4rem;">
+      <a href="{{ $page.RelPermalink }}">{{ $page.Title }}</a>
+    </li>
+  {{ end }}
+</ul>
+{{ end }}


### PR DESCRIPTION
**Notes for Reviewers**

Related PR https://github.com/meshery/meshery/pull/19713

- Added a related-reading partial.
#### How it works?
- Similar to related videos, it checks the current page’s categories and tags and uses Hugo’s related content engine to find and rank similar documentation pages.
- Category matches are weighted higher than tag matches for better relevance (if two pages share the category `Kubernetes`, they receive a higher relevance score than pages sharing only a tag like `Meshery`, so Kubernetes-related docs are prioritized higher in Related Reading.)
- Falls back to taxonomy-based matching if no related pages are found.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
