### PR TITLE
docs(cloud): clarify custom-domain eTLD distinction and identity providers

### DIFF
--- a/content/en/cloud/guides/self-hosted/planning/identity-services.md
+++ b/content/en/cloud/guides/self-hosted/planning/identity-services.md
@@ -29,7 +29,7 @@ By default, every organization signs users in through your deployment's **shared
 
 ### Bring Your Own Credentials (BYOC)
 
-An organization can optionally **bring its own credentials (BYOC)**: its own Google OAuth client and GitHub OAuth App. With BYOC, the upstream consent screen, the registered redirect URL, and the entire OAuth round trip carry the organization's own branding and stay on the organization's own domain. BYOC is enabled per organization by a [Provider Administrator](/cloud/concepts/identity-and-security/roles/provider-admin-roles/); an organization owner then registers the OAuth client ID and secret.
+An organization can optionally **bring its own credentials (BYOC)**: its own Google OAuth client and GitHub OAuth App. With BYOC, the upstream consent screen, the registered redirect URL, and the entire OAuth round trip carry the organization's own branding and stay on the organization's own domain. BYOC is enabled per organization by a [Provider Administrator](/cloud/concepts/identity-and-security/roles/#provider-admin-role); an organization owner then registers the OAuth client ID and secret.
 
 ### When BYOC is optional vs. required
 

--- a/content/en/cloud/guides/self-hosted/planning/identity-services.md
+++ b/content/en/cloud/guides/self-hosted/planning/identity-services.md
@@ -22,3 +22,26 @@ Layer5 Cloud is also working toward being the IDP for Layer5 by supporting OIDC.
 The following diagram illustrates the architecture of Layer5 Cloud.
 
 ![self-hosted-deployment](../images/self-hosted-deployment.svg "image-center-no-shadow")
+
+## Identity providers and custom domains
+
+By default, every organization signs users in through your deployment's **shared (default) identity providers** — the Google and GitHub OAuth applications configured for the Provider Organization. Users see those applications' name and logo on the Google or GitHub consent screen, and no per-organization setup is required.
+
+### Bring Your Own Credentials (BYOC)
+
+An organization can optionally **bring its own credentials (BYOC)**: its own Google OAuth client and GitHub OAuth App. With BYOC, the upstream consent screen, the registered redirect URL, and the entire OAuth round trip carry the organization's own branding and stay on the organization's own domain. BYOC is enabled per organization by a [Provider Administrator](/cloud/concepts/identity-and-security/roles/provider-admin-roles/); an organization owner then registers the OAuth client ID and secret.
+
+### When BYOC is optional vs. required
+
+Whether BYOC is *optional* or *required* depends on your organization's [custom domain](/cloud/guides/self-hosted/white-labeling/#social-sign-in-on-a-custom-domain) and how it relates to the **base domain** (the registrable domain, or eTLD+1) of your deployment:
+
+| Organization's domain | Default identity providers | BYOC |
+| --- | --- | --- |
+| No custom domain, or a subdomain of the deployment's base domain (e.g. `team.example.com` on a `cloud.example.com` deployment) | Social sign-in works out of the box | **Optional** — only for your own branding, scale, or isolation |
+| A fully-custom domain on a different base domain (e.g. `meshery.yourcompany.com` pointed at the hosted `cloud.layer5.io`) | Social sign-in cannot complete | **Required** for Google / GitHub sign-in |
+
+On a fully-custom domain **without** BYOC, the Google and GitHub buttons are hidden on the login and sign-up screens and users sign in with email and password. Configuring the organization's own identity providers restores the social buttons on that domain.
+
+{{< alert type="info" >}}
+For the custom-domain setup walkthrough and the on-eTLD vs. off-eTLD distinction, see [White-labeling → Social sign-in on a custom domain](/cloud/guides/self-hosted/white-labeling/#social-sign-in-on-a-custom-domain).
+{{< /alert >}}

--- a/content/en/cloud/guides/self-hosted/white-labeling/_index.md
+++ b/content/en/cloud/guides/self-hosted/white-labeling/_index.md
@@ -182,6 +182,18 @@ $ dig WWW.EXAMPLE.COM +nostats +nocomments +nocmd
 <!-- FUTURE: SUPPORT FOR HTTPS 
 Optionally, to enforce HTTPS encryption for your site, select Enforce HTTPS. It can take up to 24 hours before this option is available. -->
 
+### Social sign-in on a custom domain
+
+Whether social sign-in (Google and GitHub) works on a custom domain depends on how that domain relates to the **base domain** of your Layer5 Cloud deployment — its registrable domain, technically the [eTLD+1](https://developer.mozilla.org/en-US/docs/Glossary/eTLD) (for example `layer5.io` or `example.com`).
+
+- **Same base domain.** If the custom domain is a subdomain of your deployment's base domain — for example a deployment at `cloud.example.com` with a `meshery.example.com` custom domain (or, on the hosted service, a Layer5-provisioned partner subdomain such as `partner.layer5.io`) — the sign-in session is shared across that base domain, so **Google and GitHub sign-in work out of the box** with the deployment's default identity providers. No per-organization setup is required.
+
+- **Different base domain (fully-custom).** If the custom domain sits on a different base domain — for example you CNAME `meshery.yourcompany.com` to the hosted `cloud.layer5.io`, where `yourcompany.com` and `layer5.io` are different base domains — the secure social sign-in handshake cannot hand off between the two unrelated domains using the shared default identity providers. **Social sign-in on a fully-custom domain therefore requires your organization to bring its own identity provider credentials (BYOC)**: your own Google OAuth client and GitHub OAuth App, registered against your domain.
+
+{{< alert title="Social buttons are hidden until your own identity providers are configured" color="info" >}}
+On a fully-custom domain **without** its own identity providers, the Google and GitHub buttons are **hidden** on the login and sign-up screens — they would otherwise lead to a sign-in that cannot complete. **Email-and-password sign-in remains fully available**, and the social buttons reappear automatically once your organization configures its own identity providers. See [Identity Services](/cloud/guides/self-hosted/planning/identity-services/) for what BYOC is and when it is required.
+{{< /alert >}}
+
 ## Frequently asked questions about white labeling
 
 <details>


### PR DESCRIPTION
## What this does

Documents, in the customer-facing Cloud docs, the distinction between **on-eTLD** and **off-eTLD (fully-custom)** custom domains and how that determines **Identity Provider** behavior for social sign-in.

Whether Google/GitHub sign-in works on a custom domain depends on whether the domain shares the deployment's **base domain (eTLD+1)**:

- **Same base domain** (a subdomain, e.g. `team.example.com` on a `cloud.example.com` deployment): social sign-in works out of the box with the deployment's default identity providers.
- **Different base domain** (fully-custom, e.g. `meshery.yourcompany.com` CNAME'd to `cloud.layer5.io`): social sign-in cannot complete with the shared default providers, so the organization must **bring its own identity provider credentials (BYOC)**. Without BYOC the Google/GitHub buttons are hidden and users sign in with email and password.

This brings the docs in line with the behavior shipped in Layer5 Cloud `v1.0.111` (hide OAuth buttons for non-BYOC tenants on fully-custom domains).

## Changes

- **`guides/self-hosted/white-labeling/_index.md`** — new *"Social sign-in on a custom domain"* subsection under **Custom Domain Name and Login Screen**, explaining the on-eTLD vs off-eTLD distinction and the BYOC requirement, with a callout that the social buttons are hidden (and email/password remains) until an org configures its own identity providers.
- **`guides/self-hosted/planning/identity-services.md`** — new *"Identity providers and custom domains"* section covering default (Provider Organization) credentials vs **BYOC**, and a matrix of when BYOC is optional vs required based on the custom domain's base domain. Cross-linked to the white-labeling section.

## Testing

- Structural validation run locally: `{{< alert >}}` shortcodes balanced, the GFM table is well-formed, internal cross-link anchors resolve to the new headings, and link syntax is clean.
- A full Hugo build was **not** run locally (Hugo isn't installed in this environment and theme modules aren't vendored); the Netlify/CI preview build will exercise rendering. All shortcodes reuse patterns already present and rendering on these two pages.

## Notes

No new pages added — the distinction is folded into the two existing pages that already cover custom domains and identity, with reciprocal cross-links. Aliases/URLs unchanged.
