### PR TITLE
Fix: resolve 404 page asset loading on nested routes

### DIFF
--- a/.github/workflows/build-and-preview-docs.yml
+++ b/.github/workflows/build-and-preview-docs.yml
@@ -72,6 +72,7 @@ jobs:
         if: github.event.action != 'closed'
         env:
           HUGO_PREVIEW: 'true'
+          HUGO_PREVIEW_BASE_URL: https://docs.layer5.io/pr-preview/pr-${{ github.event.pull_request.number }}/
         run: |
           npm run build:preview
           cat > public/robots.txt <<'EOF'
@@ -145,7 +146,7 @@ jobs:
         with:
           header: pr-preview
           message: |
-            🚀 Preview deployment: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/
+            🚀 Preview deployment: https://docs.layer5.io/pr-preview/pr-${{ github.event.pull_request.number }}/
             > *Note: Preview may take a moment (GitHub Pages deployment in progress). Please wait and refresh. Track deployment [here](https://github.com/${{ github.repository }}/actions/workflows/pages/pages-build-deployment)*
 
       - name: Comment on pruned previews

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -57,7 +57,7 @@ jobs:
           hugo \
             --gc \
             --minify \
-            --baseURL "/"
+            --baseURL "https://docs.layer5.io/"
           cp CNAME public/CNAME
           touch public/.nojekyll
       - name: Deploy to GitHub Pages

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,6 +1,19 @@
 <!doctype html>
 <html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.Direction }}" class="no-js">
   <head>
+    {{- $baseHref := .Site.BaseURL -}}
+    {{- with getenv "HUGO_PREVIEW_BASE_URL" -}}
+      {{- $baseHref = . -}}
+    {{- end }}
+    <script>
+      (function () {
+        var previewBase = window.location.pathname.match(/^\/pr-preview\/pr-\d+\//);
+        if (previewBase && window.location.pathname !== previewBase[0] + "404.html") {
+          window.location.replace(previewBase[0] + "404.html");
+        }
+      })();
+    </script>
+    <base href="{{ $baseHref }}">
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -5,6 +5,9 @@
     {{- with getenv "HUGO_PREVIEW_BASE_URL" -}}
       {{- $baseHref = . -}}
     {{- end }}
+    {{- if not (strings.HasSuffix $baseHref "/") -}}
+      {{- $baseHref = printf "%s/" $baseHref -}}
+    {{- end }}
     <script>
       (function () {
         var previewBase = window.location.pathname.match(/^\/pr-preview\/pr-\d+\//);
@@ -47,4 +50,3 @@
     {{ partial "scripts.html" . }}
   </body>
 </html>
-

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,10 +3,7 @@
   <head>
     {{- $baseHref := .Site.BaseURL -}}
     {{- with getenv "HUGO_PREVIEW_BASE_URL" -}}
-      {{- $baseHref = . -}}
-    {{- end }}
-    {{- if not (strings.HasSuffix $baseHref "/") -}}
-      {{- $baseHref = printf "%s/" $baseHref -}}
+      {{- $baseHref = printf "%s/" (strings.TrimSuffix "/" .) -}}
     {{- end }}
     <script>
       (function () {


### PR DESCRIPTION
**Notes for Reviewers**

* This PR fixes the 404 page asset resolution issue for nested missing routes in production (e.g., `/foo/bar`) by ensuring assets resolve correctly from the appropriate base path.
* The fix preserves relative asset behavior for GitHub Pages PR previews under `/pr-preview/pr-<number>/`.
* **Important:** URLs such as `/pr-preview/pr-1073/j` are currently served by the root GitHub Pages `404.html`, not the preview folder’s `404.html`. As a result, the exact preview behavior will fully work after the root `404.html` is deployed with this redirect logic (post-merge production deploy).
* Tested on nested missing routes and PR preview paths to ensure styling loads correctly.

**Screenshot**
<img width="1470" height="884" alt="Screenshot 2026-06-04 at 5 13 59 PM" src="https://github.com/user-attachments/assets/cae6d33a-e337-4a7e-bb22-0230fcddbfc3" />

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
