### PR TITLE
Bump Go version to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer5io/docs
 
-go 1.23
+go 1.26.4
 
 require (
 	github.com/google/docsy v0.14.3 // indirect


### PR DESCRIPTION
## Description

This PR bumps the Go language version to `1.26.4` to keep the project's dependencies and build environments up to date.

**Changes include:**
* Updated the `go` directive in `go.mod` files to `1.26.4`.
* Updated the `golang` base image tags in `Dockerfile`s to `1.26.4`.

## Related Issue(s)
* Nil

## Related Issue(s)
* Addresses meshery/meshery#19875

## Type of change
- [x] Chore (updates to build processes)


