### PR TITLE
[Docs] Add Kubernetes Component Configuration Reference Guide

### DIFF
--- a/content/en/kanvas/reference/kubernetes-components.md
+++ b/content/en/kanvas/reference/kubernetes-components.md
@@ -1,0 +1,84 @@
+---
+title: Kubernetes Components Reference
+description: A no-fluff guide to configuring Kubernetes components in Kanvas.
+weight: 20
+categories: [Designer, Reference]
+tags: [kubernetes, configuration]
+---
+
+When designing infrastructure in Kanvas, dragging complex Kubernetes components (like a Service or Deployment) onto the canvas opens a configuration panel. This panel exposes the underlying YAML specification as editable fields. 
+
+This reference guide explains the most commonly used configuration properties for Kubernetes components, providing clarity on expected syntax, typical values, and how these settings affect your cluster's behavior.
+
+## Kubernetes Deployment
+
+A Deployment provides declarative updates for Pods and ReplicaSets. It allows you to describe an application's lifecycle, such as which images to run, how many replicas there should be, and the strategy for updating them.
+
+### General Configurations
+
+* **`replicas`** *(integer)*
+  * **What it does:** Specifies the desired number of identical Pods to run concurrently.
+  * **Behavior:** If set to `3`, Kubernetes' control loop continuously monitors the cluster to ensure exactly 3 Pods are running. If a Pod crashes or is deleted, a replacement is automatically provisioned.
+
+* **`selector`** *(object)*
+  * **What it does:** A label query over Pods that should match the replica count.
+  * **Behavior:** This tells the Deployment exactly *which* Pods it is responsible for managing. The selector must exactly match the labels defined in the `template`.
+
+* **`template`** *(object)*
+  * **What it does:** The blueprint used to create new Pods.
+  * **Behavior:** It contains the metadata (like labels) and the `spec` (like `containers`, `images`, and `ports`) for every Pod managed by this Deployment.
+
+* **`revisionHistoryLimit`** *(integer)*
+  * **What it does:** Specifies the number of old ReplicaSets to retain to allow rollback.
+  * **Behavior:** Defaults to 10. If set to `0`, you cannot roll back to previous versions of the Deployment.
+
+* **`paused`** *(boolean)*
+  * **What it does:** Indicates whether the deployment is paused.
+  * **Behavior:** If set to `true`, you can apply multiple updates to the Deployment without triggering a rollout until it is unpaused. Useful for batching multiple changes at once.
+
+### Rollout Strategies and Health
+
+* **`strategy`** *(object)*
+  * **What it does:** Describes the update strategy used to replace existing Pods with new ones when the Deployment is updated (e.g., when changing the container image).
+  * **Expected values:**
+    * `RollingUpdate` (Default): Gradually replaces old Pods with new ones, ensuring zero downtime.
+    * `Recreate`: Terminates all existing Pods before creating new ones, causing temporary downtime but avoiding version mixing.
+
+* **`minReadySeconds`** *(integer)*
+  * **What it does:** The minimum number of seconds a newly created Pod should be "ready" (without any of its containers crashing) for it to be considered fully available.
+  * **Behavior:** This is crucial for rolling updates. It artificially slows down the rollout to ensure the newly started application actually remains stable before tearing down the older instances.
+
+* **`progressDeadlineSeconds`** *(integer)*
+  * **What it does:** The maximum time in seconds the Deployment controller waits for a rollout to make progress before considering it "failed".
+  * **Behavior:** If a new Pod gets stuck in a crash loop due to a bad configuration or image, the Deployment will stop trying to roll out after this deadline (defaults to 600s) and report a `ProgressDeadlineExceeded` error condition.
+
+---
+
+## Kubernetes Service
+
+A Service is an abstract way to expose an application running on a set of Pods as a network service. Since Pods are ephemeral and their IP addresses change, a Service provides a stable endpoint.
+
+### Networking and Routing
+
+* **`type`** *(string)*
+  * **What it does:** Determines how the Service is exposed to the network.
+  * **Expected values:**
+    * `ClusterIP` (Default): Exposes the Service on an internal IP. Only reachable from within the cluster.
+    * `NodePort`: Exposes the Service on a static port on each Node's IP. Reachable from outside the cluster.
+    * `LoadBalancer`: Provisions a cloud provider's external load balancer to expose the Service to the public internet.
+    * `ExternalName`: Maps the Service to a DNS name (e.g., `db.example.com`).
+
+* **`selector`** *(object)*
+  * **What it does:** Key-value pairs used to identify which Pods this Service should route traffic to.
+  * **Behavior:** If a Service has a selector of `app: frontend`, it will automatically discover and load-balance traffic across all Pods in the namespace that possess the `app: frontend` label. 
+
+* **`ports`** *(array)*
+  * **What it does:** Defines the network ports exposed by the Service.
+  * **Expected values:** Contains objects with the following keys:
+    * `port`: The stable port exposed by the Service itself.
+    * `targetPort`: The port on the underlying Pod that the traffic is forwarded to.
+    * `protocol`: Typically `TCP`, `UDP`, or `SCTP`.
+
+* **`clusterIP`** *(string)*
+  * **What it does:** The stable internal IP address of the service.
+  * **Behavior:** Usually left blank to be assigned automatically by Kubernetes. It can be explicitly set to `None` to create a "Headless Service." Headless Services bypass the typical load-balancing proxy and instead allow clients to directly resolve the IP addresses of the individual backing Pods via DNS.

--- a/content/en/kanvas/reference/kubernetes-components.md
+++ b/content/en/kanvas/reference/kubernetes-components.md
@@ -30,7 +30,7 @@ A Deployment provides declarative updates for Pods and ReplicaSets. It allows yo
 
 * **`revisionHistoryLimit`** *(integer)*
   * **What it does:** Specifies the number of old ReplicaSets to retain to allow rollback.
-  * **Behavior:** Defaults to 10. If set to `0`, you cannot roll back to previous versions of the Deployment.
+  * **Behavior:** Defaults to `10`. If set to `0`, you cannot roll back to previous versions of the Deployment.
 
 * **`paused`** *(boolean)*
   * **What it does:** Indicates whether the deployment is paused.
@@ -50,7 +50,7 @@ A Deployment provides declarative updates for Pods and ReplicaSets. It allows yo
 
 * **`progressDeadlineSeconds`** *(integer)*
   * **What it does:** The maximum time in seconds the Deployment controller waits for a rollout to make progress before considering it "failed".
-  * **Behavior:** If a new Pod gets stuck in a crash loop due to a bad configuration or image, the Deployment will stop trying to roll out after this deadline (defaults to 600s) and report a `ProgressDeadlineExceeded` error condition.
+  * **Behavior:** If a new Pod gets stuck in a crash loop due to a bad configuration or image, the Deployment will stop trying to roll out after this deadline (defaults to `600s`) and report a `ProgressDeadlineExceeded` error condition.
 
 ---
 
@@ -70,7 +70,7 @@ A Service is an abstract way to expose an application running on a set of Pods a
 
 * **`selector`** *(object)*
   * **What it does:** Key-value pairs used to identify which Pods this Service should route traffic to.
-  * **Behavior:** If a Service has a selector of `app: frontend`, it will automatically discover and load-balance traffic across all Pods in the namespace that possess the `app: frontend` label. 
+  * **Behavior:** If a Service has a selector of `app: frontend`, it will automatically discover and load-balance traffic across all Pods in the namespace that possess the `app: frontend` label.
 
 * **`ports`** *(array)*
   * **What it does:** Defines the network ports exposed by the Service.


### PR DESCRIPTION
**Notes for Reviewers**

### The Problem:
Previously, users dragging complex Kubernetes components (like `Service` or `Deployment`) onto the Kanvas canvas were met with a wall of configuration fields. While the UI tooltips provide brief hints, there was no centralized, comprehensive documentation explaining what these properties actually do or how they affect the infrastructure.
### The Solution:
This PR resolves the issue by creating a new "no-fluff" reference guide specifically tailored for Kanvas component configurations. 
I've audited the Kanvas UI for Kubernetes components and drafted the initial behavior-focused guides for the most requested components:
1. **Kubernetes Deployment:** Documented `replicas`, `strategy` (RollingUpdate vs Recreate), `selector`, `template`, `minReadySeconds`, `progressDeadlineSeconds`, `revisionHistoryLimit`, and `paused`.
2. **Kubernetes Service:** Documented networking behaviors including `type` (ClusterIP, NodePort, LoadBalancer), `selector`, `ports`, and `clusterIP`.
For each property, the documentation strictly adheres to the requested format:
- **What it does:** Plain English explanation of the field.
- **Expected values/Syntax:** How to correctly fill it out.
- **Behavior:** How tweaking the setting practically affects the cluster infrastructure.
This provides the much-needed inline guidance for beginners to confidently design architectures in Kanvas. 
### Location of changes:
- Created: `content/en/kanvas/reference/kubernetes-components.md`


Preview -> 

<img width="2880" height="1718" alt="{C24D6673-5299-4581-9EE6-C47394CB3C20}" src="https://github.com/user-attachments/assets/68f033c5-cfb3-4d68-9d91-982a31d075de" />

<img width="2880" height="1712" alt="image" src="https://github.com/user-attachments/assets/d780d886-cdf7-4c8f-99e7-37e029f5b802" />

<img width="2880" height="1723" alt="{C1478E45-CDE7-4ADB-968B-06BADDBC0950}" src="https://github.com/user-attachments/assets/5856db47-b795-4c02-8636-6d2141a9f835" />


This PR fixes #920 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [✅ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
