### PR TITLE
docs(academy): Organization filter hidden on a host org's Academy domain

### DIFF
--- a/content/en/cloud/academy/using-the-academy/index.md
+++ b/content/en/cloud/academy/using-the-academy/index.md
@@ -29,6 +29,12 @@ First you will see a collection of content cards. Each card gives you a quick ov
 
 ![Academy Catalog Overview](./images/academy-catalog.gif)
 
+Use the filters on the left - **Level**, **Content Type**, and, when browsing the full Layer5 Academy, **Organization** - to narrow the catalog to what you are looking for.
+
+{{< alert type="info" title="Browsing an Organization's Own Academy" >}}
+When you visit an organization's own Academy on its custom domain (for example, `exoscale.layer5.io`), the catalog is automatically scoped to that organization's content and the **Organization** filter is hidden, so you stay focused on that academy's offerings. To browse the full cross-organization catalog, visit the main Layer5 Academy at [cloud.layer5.io/academy](https://cloud.layer5.io/academy), where the **Organization** filter is available.
+{{< /alert >}}
+
 ### Understanding Content Types
 
 To help you choose the right content for your goals, we offer three distinct types. You can use the Content Type filter on the left to narrow your search.


### PR DESCRIPTION
## Summary

Documents the Academy catalog behavior shipped in layer5io/meshery-cloud#5562:

- Visiting an organization's own Academy on its custom domain (e.g. `exoscale.layer5.io/academy`) scopes the catalog to that organization's content and **hides the Organization filter**, keeping visitors focused on that academy's offerings.
- The full cross-organization catalog remains browsable at `cloud.layer5.io/academy`, where the **Organization** filter is available.

Also adds a one-line description of the **Level / Content Type / Organization** filters to the "Navigating the Catalog" section.

## Related

- Code PR: layer5io/meshery-cloud#5562