### PR TITLE
docs: replace hardcoded Related Docs with Related Reading

### DIFF
--- a/content/en/cloud/concepts/identity-and-security/_index.md
+++ b/content/en/cloud/concepts/identity-and-security/_index.md
@@ -5,7 +5,7 @@ description: >
   Organizations, teams, users, roles, keychains, keys, sessions, and tokens.
 weight: 3
 categories: [Identity, Security]
-tags: [permissions, identity, authentication]
+tags: [permissions, identity, authentication, orgs]
 aliases:
   - /cloud/identity/
   - /cloud/security/

--- a/content/en/cloud/guides/organizations/configuration-scenarios/index.md
+++ b/content/en/cloud/guides/organizations/configuration-scenarios/index.md
@@ -194,10 +194,3 @@ email-domain allowlists, role and team assignment, quotas, and expiry). Any
 scenario above can be paired with any membership policy. See
 [Organization Management → Inviting members](/cloud/guides/organizations/org-management/)
 and [User Invitations](/cloud/concepts/identity-and-security/users/user-invitations/).
-
-## Related
-
-- [White-labeling (Rebranding)](/cloud/guides/self-hosted/white-labeling/) — themes, logos, custom domains, and the social-sign-in details.
-- [Identity Services](/cloud/guides/self-hosted/planning/identity-services/) — BYOC, OIDC single sign-on, and authentication boundaries.
-- [Organizations (concept)](/cloud/concepts/identity-and-security/organizations/) — organizations as the unit of multi-tenancy.
-- [Identity and Security → Security Boundaries](/cloud/concepts/identity-and-security/#security-boundaries) — how authentication and authorization boundaries compose.

--- a/content/en/cloud/guides/self-hosted/planning/identity-services/index.md
+++ b/content/en/cloud/guides/self-hosted/planning/identity-services/index.md
@@ -2,7 +2,7 @@
 title: Identity Services
 description: "Understand identity services prerequisites and how to integrate your existing identity with OIDC."
 categories: [Self-Hosted]
-tags: [identity]
+tags: [identity, byoc, orgs]
 weight: 3
 aliases:
   - /cloud/self-hosted/planning/identity-services/

--- a/content/en/cloud/guides/self-hosted/white-labeling/_index.md
+++ b/content/en/cloud/guides/self-hosted/white-labeling/_index.md
@@ -2,6 +2,7 @@
 title: White-labeling (Rebranding)
 weight: 1
 categories: [Self-Hosted]
+tags: [white-labeling, custom-domain, orgs]
 description: >
   Customize the appearance and branding of your engineering platform powered by Layer5 Cloud. 
 aliases:

--- a/content/en/kanvas/advanced/autopan.md
+++ b/content/en/kanvas/advanced/autopan.md
@@ -107,9 +107,3 @@ If autopan is disabled on a design where you would like it to be active, you hav
 1. **Switch to a lower-fidelity render mode.** Wireframe and View-Only raise the threshold to 1,000 nodes. See the [Render Modes]({{< ref "kanvas/advanced/render-modes.md" >}}) page for what each mode costs and what it hides.
 2. **Reduce the live listener count.** The [Layers Panel]({{< ref "kanvas/advanced/performance/index.md" >}}) lets you disable layers of visual information (badges, tags, feasibility indicators) that contribute to the pan fan-out. Turning off a layer effectively moves the threshold upward because there are fewer listeners to amplify each pan.
 3. **Break the design into smaller designs.** If you are consistently bumping the threshold in your preferred render mode, the design might be past the scale Kanvas targets for interactive editing. Splitting it into referenced sub-designs keeps each one within the sweet spot.
-
-### Related pages
-
-- [Render Modes]({{< ref "kanvas/advanced/render-modes.md" >}}) — what each mode renders, what it hides, and how Adaptive Render Mode flips between them automatically.
-- [Performance Limits and Tuning]({{< ref "kanvas/advanced/performance/index.md" >}}) — overall Kanvas performance envelope and the Layers Panel.
-- [Design Render Quality]({{< ref "kanvas/advanced/url-parameters/index.md" >}}) — overriding the render mode via URL parameters (useful for snapshots and embeds).

--- a/content/en/kanvas/advanced/performance/index.md
+++ b/content/en/kanvas/advanced/performance/index.md
@@ -103,10 +103,6 @@ To optimize performance, consider the following:
 
 As your designs grow in complexity, certain design patterns can impact how smoothly Kanvas responds. Understanding these factors helps you create designs that remain fast and responsive.
 
-{{< alert type="info" title="Related performance controls" >}}
-This page covers the design patterns and tuning levers that affect Kanvas performance. For the per-mode rendering ladder (Full, Medium, Wireframe, View-Only) and automatic fidelity management, see [Render Modes]({{< ref "kanvas/advanced/render-modes.md" >}}). For the drag-to-edge viewport pan and its per-render-mode size thresholds, see [Auto-pan on Drag]({{< ref "kanvas/advanced/autopan.md" >}}).
-{{< /alert >}}
-
 ### Working with Grouped Components
 
 When you create groups of components (placing multiple components inside a parent container), you might notice performance differences as the number of grouped items increases. Here's what you might experience:

--- a/content/en/kanvas/advanced/render-modes.md
+++ b/content/en/kanvas/advanced/render-modes.md
@@ -231,9 +231,3 @@ All four render modes work in both Designer and Operator contexts:
 - In **Designer mode**, render modes control the fidelity of your editable design canvas. All modes except View Only allow full editing.
 - In **Operator mode**, the `managed-by-Meshery` and `terminal session` badges follow the same suppression rules as in Designer — they are visible in Full mode and hidden in Medium, Wireframe, and View Only modes.
 - **View Only mode is particularly useful in Operator** for monitoring dashboards where accidental edits should be prevented.
-
-## Related pages
-
-- [Auto-pan on Drag]({{< ref "kanvas/advanced/autopan.md" >}}) — the most visible feature gated per render mode.
-- [Performance Limits and Tuning]({{< ref "kanvas/advanced/performance/index.md" >}}) — full performance envelope and the Layers Panel.
-- [Design Render Quality]({{< ref "kanvas/advanced/url-parameters/index.md" >}}) — URL parameter overrides for render mode.

--- a/content/en/kanvas/designer/_index.md
+++ b/content/en/kanvas/designer/_index.md
@@ -4,7 +4,7 @@ description: >
   Designer mode is for those who want to create their own Kanvas, using the palette of components provided by Meshery.
 weight: 4
 categories: [Designer]
-# tags: [designs]
+tags: [designer-overview]
 aliases:
   - /meshmap/designer/
 ---

--- a/content/en/kanvas/designer/understanding-tool-modes/index.md
+++ b/content/en/kanvas/designer/understanding-tool-modes/index.md
@@ -4,7 +4,7 @@ description: >
   Kanvas Designer offers three modes: Default, Pencil, and Connector, which behave differently based on the context in which they are used. Learn how to interact with components and the canvas in each mode.
 weight: 3
 categories: [Designer]
-tags: [designs]
+tags: [designs, Dock]
 aliases:
 ---
 

--- a/content/en/kanvas/operator/_index.md
+++ b/content/en/kanvas/operator/_index.md
@@ -4,6 +4,7 @@ weight: 5
 description: >
   Operator mode is for operating your Kubernetes clusters and cloud native infrastructure. 
 categories: [Operator]
+tags: [operator-overview]
 aliases:
   - /meshmap/operator
 ---

--- a/content/en/kanvas/operator/interactive-terminal/index.md
+++ b/content/en/kanvas/operator/interactive-terminal/index.md
@@ -3,6 +3,7 @@ title: Interactive Terminal
 description: >
   Learn about Interactive Terminal in Operator mode 
 categories: [Operator]
+tags: [troubleshooting]
 ---
 
 When operating cloud native infrastructure, deep diagnostics often require direct access to the container shell. The **Interactive Terminal** in Kanvas enables you to execute commands and inspect the filesystem of your running containers directly from the visual topology. By integrating terminal sessions into the Kanvas interface, you can troubleshoot issues, verify configurations, and test network connectivity without switching context to external CLI tools like `kubectl`.
@@ -72,10 +73,3 @@ While using the interactive terminal, understand that you can only open one sess
 <!-- {{< figure src="images/interactive-terminal-sequence-diagram.svg" link="images/interactive-terminal-sequence-diagram.svg"  width="100%" alt="interactive-terminal-sequence-diagram" >}} -->
 
 ![interactive-terminal-sequence-diagram](images/interactive-terminal-sequence-diagram.svg)
-
-***
-
-### See Also
-
-* **[Log Streaming]({{< ref "kanvas/operator/log-streaming/index.md" >}}):** Learn how to live-tail logs for real-time application monitoring.
-<!-- * **[Performance Management]({{< ref "kanvas/advanced/performance/index.md" >}}):** Run load tests and analyze performance profiles. -->

--- a/content/en/kanvas/operator/log-streaming/index.md
+++ b/content/en/kanvas/operator/log-streaming/index.md
@@ -3,6 +3,7 @@ title: Log Streaming
 description: >
   Learn about Log Streaming in Operator mode 
 categories: [Operator]
+tags: [troubleshooting]
 ---
 
 Efficient troubleshooting requires immediate visibility into your application's behavior. The **Log Streamer** in Kanvas allows you to live-tail logs from your Kubernetes pods and containers directly within the visual topology. Unlike static log files, this feature provides a real-time, multiplexed view of your infrastructure's activities, enabling you to debug interactions between services without leaving the Kanvas interface.
@@ -61,10 +62,3 @@ Once the stream is active, the Log Streamer panel will display the output.
 The Log Streamer utilizes a robust architecture where the **Meshery Operator** signals the **MeshSync** controller to start the log flow. Data is streamed using **NATS** to the Meshery Broker, preprocessed, and then delivered to your browser via a **WebSocket** connection using GraphQL subscriptions. This ensures minimal latency and high performance, even when streaming data from multiple active containers.
 
 ![log-stream-sequence-diagram](images/log-stream-sequence-diagram.svg)
-
-***
-
-### See Also
-
-* **[Interactive Terminal]({{< ref "kanvas/operator/interactive-terminal/index.md" >}}):** Learn how to establish an interactive shell session with your containers.
-* **[Performance Management]({{< ref "kanvas/advanced/performance/index.md" >}}):** Run ad-hoc performance tests alongside your log monitoring.

--- a/content/en/videos/getting-started/basics/designer-overview.md
+++ b/content/en/videos/getting-started/basics/designer-overview.md
@@ -6,12 +6,8 @@ videoId: "qaoYRP3oLok"
 videoType: youtube 
 categories: [Designer]
 formats: [video]
-tags: [basics]
+tags: [basics, designer-overview]
 duration: "1:38"
 ---
 
 {{< youtube id=qaoYRP3oLok class="yt-embed-container" >}}
-
-### Related Docs
-
-- [Exploring Designer]({{< ref "kanvas/designer/_index.md" >}})

--- a/content/en/videos/getting-started/basics/operator-overview.md
+++ b/content/en/videos/getting-started/basics/operator-overview.md
@@ -6,12 +6,8 @@ videoId: "QANUEikEwQY"
 videoType: youtube 
 categories: [Operator]
 formats: [video]
-tags: [basics]
+tags: [basics, operator-overview]
 duration: "2:11"
 ---
 
 {{< youtube id=QANUEikEwQY class="yt-embed-container" >}}
-
-### Related Docs
-
-- [Exploring Operator]({{< ref "kanvas/operator/_index.md" >}})

--- a/content/en/videos/getting-started/basics/pinning-models-to-dock.md
+++ b/content/en/videos/getting-started/basics/pinning-models-to-dock.md
@@ -22,6 +22,3 @@ There is no limit to the number of models that you can pin to the dock.
 When a model is pinned you can still browse all components or search for a specific component. Drag and drop or click to place a new component into your design.
 
 When you no longer want a model pinned to the dock, you can remove the pin by revisiting the model in its original location and choosing to “remove from dock”.
-
-Related Docs:
-1. https://docs.layer5.io/kanvas/designer/understanding-tool-modes/

--- a/content/en/videos/getting-started/comments/design-reviews-full.md
+++ b/content/en/videos/getting-started/comments/design-reviews-full.md
@@ -17,8 +17,6 @@ duration: "2:47"
 
 Use comments to offer feedback to team members, take detailed design notes, capture helpful tips for your team members, and include justification as to your infrastructure and application configuration decisions. Pay it forward to your future self by leaving historical record for reference later.
 
-Related Documentation: [Design Reviews](https://docs.layer5.io/kanvas/designer/comments/)
-
 Lessons learned in this Peer Review module:
 
 * **Collaboration is Key:** Kanvas facilitates collaborative design through peer reviews. It emphasizes both asynchronous (commenting, notifications) and synchronous (real-time discussion) methods.

--- a/layouts/partials/related-reading.html
+++ b/layouts/partials/related-reading.html
@@ -4,7 +4,8 @@
 {{ $pageTypes := $relatedReadingConfig.pageTypes | default (slice) }}
 {{ $sections := $relatedReadingConfig.sections | default (slice) }}
 
-{{ $readingPages := .Site.RegularPages.Related . }}
+{{ $candidatePages := where .Site.Pages "Kind" "in" (slice "page" "section") }}
+{{ $readingPages := $candidatePages.Related . }}
 {{ if gt (len $pageTypes) 0 }}
   {{ $readingPages = where $readingPages "Type" "in" $pageTypes }}
 {{ end }}


### PR DESCRIPTION
## Description

This PR updates the "Pinning Models to the Dock" documentation to use the existing Related Reading mechanism instead of a hardcoded Related Docs link.

### Changes
- Removed the obsolete hardcoded `Related Docs` hyperlink from the Pinning Models to the Dock page.
- Added the `Dock` tag to the Understanding Tool Modes page so it is automatically surfaced by the existing Related Reading implementation.

This keeps related content consistent with the current `related-reading.html` approach while minimizing changes.

**Resolves:** #1028
Locally tested
<img width="1912" height="900" alt="image" src="https://github.com/user-attachments/assets/b8aad6a1-3ef1-4e64-a1a5-fb390189d8c1" />
