### PR TITLE
[UI] fix(docs): prevent wide code blocks from pushing sidebar off-screen

### DIFF
--- a/assets/scss/_resizable-bootstrap-overrides.scss
+++ b/assets/scss/_resizable-bootstrap-overrides.scss
@@ -17,6 +17,7 @@
    absorb the remaining space instead of holding col-xl-8's 66.66% max-width. */
 .row > main {
   flex: 1 1 0;
+  min-width: 0;
   max-width: none;
   width: auto;
 }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -96,6 +96,10 @@ body {
   .highlight {
     overflow-x: auto;
     max-width: 100%;
+
+    pre {
+      overflow-x: visible;
+    }
   }
 
   img,

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -79,6 +79,8 @@ body {
     word-wrap: normal;
     background-color: $gray-900;
     padding: $spacer;
+    overflow-x: auto;
+    max-width: 100%;
 
     >code {
       background-color: inherit !important;
@@ -89,6 +91,11 @@ body {
       white-space: pre;
       border: 0;
     }
+  }
+
+  .highlight {
+    overflow-x: auto;
+    max-width: 100%;
   }
 
   img,


### PR DESCRIPTION
## Description
PR fixes : #1147 

On the SMTP guide (`/cloud/guides/self-hosted/operating/smtp/`), long log and code blocks were expanding the main content column past the viewport. That pushed the right "On this page" sidebar off-screen and required horizontal scrolling to read the page  inconsistent with other docs pages.

This PR applies a minimal CSS-only fix:
- Added `min-width: 0` to `.row > main` so the flex column can shrink within the layout instead of growing with wide content.
- Added `overflow-x: auto` and `max-width: 100%` to `.td-content pre` and `.td-content .highlight` so long lines scroll inside the code block instead of stretching the page.
- 
No markdown, HTML, or JS changes. The SMTP page exposed the issue, but the fix applies globally to any page with long code blocks.

## Screenshot/video

https://github.com/user-attachments/assets/22f66f5e-140c-41fd-b72f-6254de581c2a


---
**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
