### PR TITLE
Rebase release-notes commits onto master before pushing

### DIFF
--- a/.github/workflows/cloud-release-docs.yml
+++ b/.github/workflows/cloud-release-docs.yml
@@ -48,3 +48,16 @@ jobs:
           commit_user_name: l5io
           commit_user_email: ci@layer5.io
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          # The checkout above is pinned to the SHA this run was dispatched at,
+          # so anything landing on master while the job runs - notably the
+          # cross-repo chart publisher in layer5io/meshery-cloud - leaves this
+          # job pushing from a stale base and the release notes are lost with
+          # the rejected push. Replay this commit on the current tip first.
+          # Safe to rebase: this job only touches build/meshery-cloud.version
+          # and its own release-notes page, which nothing else writes.
+          # The action passes its identity per-command and never configures it,
+          # so the rebase has to be handed the same one or it picks up whatever
+          # the runner guesses.
+          before_push_hook: >-
+            git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL"
+            pull --rebase --autostash origin "$INPUT_BRANCH"

--- a/.github/workflows/meshery-extension-release-docs.yml
+++ b/.github/workflows/meshery-extension-release-docs.yml
@@ -48,3 +48,14 @@ jobs:
           commit_user_name: l5io
           commit_user_email: ci@layer5.io
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          # Same stale-base hazard as cloud-release-docs.yml: the checkout is
+          # pinned to the dispatch SHA, so any commit landing on master during
+          # the run makes this push non-fast-forward and discards the notes.
+          # Safe to rebase: this job only touches build/meshery-extensions.version
+          # and its own release-notes page, which nothing else writes.
+          # The action passes its identity per-command and never configures it,
+          # so the rebase has to be handed the same one or it picks up whatever
+          # the runner guesses.
+          before_push_hook: >-
+            git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL"
+            pull --rebase --autostash origin "$INPUT_BRANCH"


### PR DESCRIPTION
## Symptom

`https://docs.layer5.io/cloud/reference/releases/v1.0.219` was a 404. The release-notes job did its work and then threw it away.

From run [30842563575](https://github.com/layer5io/docs/actions/runs/30842563575), job "Release notes cloud with latest version", step **Commit changes**:

```
18:44:13Z  b45c8829  "Publish layer5-cloud-v1.0.219.tgz"   <- chart publisher lands on master
18:44:28Z  release-notes job commits bd9c2a5d locally:
             create mode 100644 content/en/cloud/reference/releases/v1.0.219.md
           ...then pushes:
             Your branch and 'origin/master' have diverged, and have 1 and 1 different commits each
             ! [rejected]  HEAD -> master (non-fast-forward)
             error: failed to push some refs to 'https://github.com/layer5io/docs'
```

The page was generated correctly. The push was rejected, the job failed, and the commit died with the runner.

## Root cause

Two things, and the second is the one that makes this a design defect rather than bad luck.

1. `stefanzweifel/git-auto-commit-action@v7` commits against `branch: master` with no pull, no rebase and no retry. Its only fetch is the `git fetch --depth=1` inside `_switch_to_branch`, which runs *before* the commit and never re-bases anything. A remote tip that moved after that point is terminal.
2. The `actions/checkout` step is pinned to the SHA the run was dispatched at. The exposure is therefore not a millisecond push window - it is the entire span from dispatch to push. **Rerunning the failed job reproduces the rejection deterministically**, because the rerun checks out the same stale dispatch SHA: job [91788246307](https://github.com/layer5io/docs/actions/runs/30842563575) failed identically, same `1 and 1 different commits`.

v1.0.217 and v1.0.218 survived only because the notes job happened to push first.

## Fix

Replay the job's own commit on the current tip before the action pushes, via the action's `before_push_hook`:

```yaml
before_push_hook: >-
  git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL"
  pull --rebase --autostash origin "$INPUT_BRANCH"
```

Applied to `cloud-release-docs.yml` and to its twin `meshery-extension-release-docs.yml` (identical step, identical gap).

Rebase is the right shape here because the colliding jobs write disjoint paths - this job touches only `build/meshery-cloud.version` and its own `v1.0.219.md`; the chart publisher touches only `charts/`. Nothing else writes those files, so the replay cannot conflict in practice.

### Two things worth calling out

**`pull:` is not an input of this action.** The obvious fix - `pull: '--rebase --autostash'` - would have been silently ignored and looked fixed. `pull` appears in **no** version of `action.yml` (checked v4, v5, v6, v7). `before_push_hook` is the real, documented extension point in v7: `entrypoint.sh` runs `_run_hook "before_push_hook"` immediately before `_push_to_github`, after `_local_commit`, and the file runs under `set -eu`, so a failed rebase fails the job loudly instead of pushing from a stale base.

**The identity has to be passed explicitly.** `_local_commit` supplies the identity per-invocation (`git -c user.name=... -c user.email=... commit`) and never writes it to config, so a bare `git pull --rebase` in the hook would rebase under whatever ident the runner guesses - or fail outright on a runner where git cannot guess one. Passing the action's own `$INPUT_COMMIT_USER_NAME` / `$INPUT_COMMIT_USER_EMAIL` keeps the rebased commit consistent with `commit_user_name` / `commit_user_email`.

### Residual window

A rebase closes the gap between checkout and rebase, not the gap between rebase and push. Two publishers colliding inside those microseconds still leaves one rejected. That cannot be retried from `before_push_hook`, which runs before a push it does not own - retrying would mean `skip_push: true` plus a hand-rolled clone/rebase/push loop, i.e. the rewrite this is scoped away from, and which already exists on the counterpart side. What changes here is the magnitude: the window that cost us v1.0.219 was the whole dispatch-to-push span, and the surviving failure mode is a loud red job under `set -eu` rather than a silent loss.

## The other side of the race

The competing pusher is the `Release Chart` workflow in **layer5io/meshery-cloud**, not in this repo. It has **already been hardened** - it now runs `.github/build/publish-helm-chart.sh`, which re-fetches the tip and retries with jitter on each attempt (verified against the live file on that repo's `master`). So:

- A `concurrency:` group on this workflow **cannot** serialise it - the racer is cross-repo and GitHub concurrency groups do not span repositories. It is deliberately **not** added, rather than added as decoration.
- Each side is fixed where it lives: retry-on-rejection over there, rebase-before-push here.

## Verification

**Reproduced and exercised, honestly scoped.** I could not rehearse a real cross-repo race on Actions, so I rebuilt it locally with the same primitives - a bare origin, a **shallow depth-1 clone** matching `actions/checkout`, and a competing commit landing between clone and push.

- **Baseline reproduces the failure exactly:** `! [rejected] HEAD -> master (non-fast-forward)`.
- **With the hook, the push lands** and the resulting tree contains both `charts/*.tgz` and `content/.../v1.0.219.md` - no work lost on either side.
- **Shallow clones are fine.** A concern worth checking, since `--depth 1` can leave a rebase with no reachable merge base. It does not here: verified with both 1-commit and 3-commit divergence against a shallow clone, both rebased and pushed cleanly. No `fetch-depth: 0` needed - this repo is ~1.2 GB and a full clone per release would be a poor trade.
- **Identity propagation verified** by running the snippet exactly as the action evaluates it (`set -eu; eval "$snippet"`) with no ambient git config: the rebased commit came out as `l5io <ci@layer5.io>`, matching the action's own inputs.
- `actionlint` reports no new findings on either file (the remaining shellcheck notes are pre-existing, on untouched `run:` steps).

**What this does not show:** the fix is verified by construction and by a local rehearsal of the race, **not** by a reproduced cross-repo collision on GitHub Actions. That path only exercises on the next real release.

## v1.0.219 is published

Handled separately from this PR, since rerunning could not work. A fresh `workflow_dispatch` ([run 30844765386](https://github.com/layer5io/docs/actions/runs/30844765386)) checked out current master and pushed cleanly. Verified at the source of truth, not at a green job: `content/en/cloud/reference/releases/v1.0.219.md` is on `origin/master` as of 82c88871, and `build/meshery-cloud.version` now reads `v1.0.219`.

## Flagged, not fixed here

Four workflows in this repo push to `master` with the same unguarded `git-auto-commit-action` step, and all four are on the **same** `0 0 * * *` cron: `feature-list.yml`, `generate-keys.yml`, `discussion-data-files-update.yml`, `generate-pricing-list.yml`. They race each other nightly with the identical failure mode - a losing job drops its data update in silence. The same one-line `before_push_hook` fixes each. Left out of this PR to keep it to the reported defect; happy to fold them in here or file separately, whichever reviewers prefer.
