### PR TITLE
docs: correct documentation framework from Jekyll to Hugo and Docsy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,7 @@ Or you may configure your IDE, for example, Visual Studio Code to automatically 
 <a href="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" ><img src="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" width="50%"><a>
 
 ## <a name="contributing-docs">Documentation Contribution Flow</a>
-Please contribute! Layer5 documentation uses Jekyll and GitHub Pages to host docs sites. Learn more about [Layer5's documentation framework](https://docs.google.com/document/d/17guuaxb0xsfutBCzyj2CT6OZiFnMu9w4PzoILXhRXSo/edit?usp=sharing). The process of contributing follows this flow:
+Please contribute! Layer5 documentation is built with Hugo and the Docsy theme. Learn more about [Layer5's documentation framework](https://docs.google.com/document/d/17guuaxb0xsfutBCzyj2CT6OZiFnMu9w4PzoILXhRXSo/edit?usp=sharing). The process of contributing follows this flow:
 
 1. Create a fork, if you have not already, by following the steps described [here](./CONTRIBUTING-gitflow.md)
 1. In the local copy of your fork, navigate to the docs folder.


### PR DESCRIPTION
## Description

Corrects the documentation framework named in `CONTRIBUTING.md`. The "Documentation Contribution Flow" section told contributors that Layer5 documentation "uses Jekyll and GitHub Pages to host docs sites". This repository is built with **Hugo and the Docsy theme**:

- `hugo.toml` is the site configuration
- `go.mod` requires `github.com/google/docsy v0.14.3`
- there is no `_config.yml` or `Gemfile` anywhere in the tree

The stale sentence also contradicted its own surrounding instructions, which already tell contributors to install Hugo and PostCSS in order to build the site. A new contributor reading top-to-bottom was told to set up a Jekyll toolchain this project does not use.

One line changed.

## Why the account/organization deletion content is not in this PR

This branch was originally opened to also document account-deletion and organization-deletion behaviour: that deleting your account offers to delete a sole-membership organization, that you confirm with a checkbox plus typing the organization name, that free-plan organizations are permanently deleted while paid ones have their subscription cancelled at period end with data retained, and that shared resources require separate confirmation.

**That content was verified against `layer5io/meshery-cloud` master and does not describe the shipped product, so it has been deliberately left out.** Today, account deletion soft-deletes the user record and removes the backing login identity - there is no organization handling, no organization deletion, no subscription cancellation and no ownership transfer anywhere in that path. The UI confirmation is a single Cancel/Proceed prompt with no checkbox and no name field.

The wire contract for the feature did land in `meshery/schemas`, but the corresponding design in `meshery-cloud` is still marked *Draft (design in review; pending final written-spec approval)* and no PR implements it. The docs had been written from the design spec rather than from shipped behaviour.

The draft also **removed a statement that is accurate today** - that only an Org Owner can delete an organization and Org Admins cannot (the route is gated by `AuthorizationMiddlewareForOrgOwner` plus `AuthorizationMiddlewarePreventingLastOrgDeletion`). That text is intentionally kept as-is.

Publishing the rest would have given users steps they cannot follow on a page about irreversible, destructive actions. **This is a deliberate exclusion, not an oversight - please do not re-add the deletion content until the feature exists in meshery-cloud.**

## Testing

- `hugo --gc` builds clean (exit 0, 1579 pages, no errors or broken refs) on this branch rebased onto current `master`.
- Verified `hugo.toml` and `docsy` are present and no Jekyll configuration exists.

## Notes for reviewers

The framework correction is unrelated to the deletion content described above; it is called out separately here rather than buried, since the two arrived on the same branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to reflect that Layer5 documentation uses Hugo with the Docsy theme instead of Jekyll and GitHub Pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->