### PR TITLE
docs(cloud): document filter import by URL, destination policy, and error semantics

### DIFF
--- a/content/en/cloud/concepts/catalog/_index.md
+++ b/content/en/cloud/concepts/catalog/_index.md
@@ -59,6 +59,23 @@ To publish a design into the catalog:
 1. In the design details dialog, review or update the **name**, **type**, and **description**, then click **Publish To Catalog**.
 1. After the request is submitted, maintainers approve it, and the design appears in the [public catalog](https://cloud.layer5.io/catalog).
 
+### Importing Filters
+
+WebAssembly filters can be brought into Layer5 Cloud in two ways:
+
+- **File Upload**: select the filter file from your machine and give it a name.
+- **URL Upload**: give a name and the `http` or `https` URL that serves the filter body directly.
+
+An imported filter is saved under the name you enter on the import form, whichever method you use.
+
+{{< alert title="URL import cannot reach private networks" >}}
+Layer5 Cloud is a hosted, multi-tenant service, so a URL import is fetched from Cloud's own network rather than from your machine. A URL whose host resolves - or redirects - to a loopback, link-local, private, carrier-grade NAT, or IPv6 unique-local address is refused, and only `http` and `https` URLs are accepted.
+
+If your filter lives on an internal host, a private network, or anything else Cloud cannot reach from the public internet - an internal Git server, for example - use **File Upload** instead. It is the supported path for those sources and no capability is lost. There is deliberately no allowlist or opt-out setting.
+{{< /alert >}}
+
+If an import URL is mistyped, has moved, or answers with anything other than a success status, the import fails with **400 Bad Request**: the URL is the problem, so check that it is reachable from the public internet and serves the filter body itself rather than a download page. A `500` or `502` means the fetch itself failed in transit (for example a connection, TLS, or timeout failure) against a URL that was otherwise permitted.
+
 ### Content Tags
 
 - Arbitrary strings for categorization.


### PR DESCRIPTION
## Intent

Document three newly user-visible Layer5 Cloud filter-import behaviours that shipped in [layer5io/meshery-cloud#5908](https://github.com/layer5io/meshery-cloud/pull/5908) and were not covered by any existing page. Each one is something a user can walk into and be surprised by, so each is stated where a user hitting it would look.

## What Changed

One section, `### Importing Filters`, added to `content/en/cloud/concepts/catalog/_index.md` - the page that already defines Filters as a catalog content category - rather than a new page, so nothing is orphaned:

- **URL import destination policy.** A URL import is fetched from Cloud's own network, so a destination resolving or redirecting to loopback, link-local, private, CGNAT, or IPv6 unique-local space is refused, and only `http`/`https` is accepted. Private-network sources use **File Upload**, which is stated as the supported route, with the deliberate absence of an allowlist or opt-out noted so it does not read as a gap.
- **Error semantics.** A mistyped, moved, or non-success import URL fails with 400 (the URL is the caller's to fix); 5xx remains for a genuine transport failure against an otherwise permitted destination.
- **Naming.** An imported filter keeps the name submitted on the import form, whichever method is used.

Written user-facing only: no code paths, no error codes, no CIDR lists beyond the range names a user needs to recognise their own address. Text-only, per the repo's screenshots policy - no screenshots were fabricated. Uses the existing `{{< alert title="..." >}}` shortcode already used across `content/en/cloud/concepts/`.

Each claim was verified against the merged diff rather than restated from the issue: the destination predicate and scheme allowlist in `server/handlers/meshery_filters_import.go`, the 400-vs-500 split in `filterImportHTTPStatus`, and the supplied-name path in `remoteFilter` (`filterName = requestBody.FilterData.Name`, with the generated UUID now only a fallback when no name is supplied).

Fixes #1188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for importing WebAssembly filters into Layer5 Cloud through file or URL uploads.
  * Documented naming behavior, private-network URL restrictions, and when to use file uploads.
  * Added explanations of common import failure responses, including 400, 500, and 502 errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->