### PR TITLE
[Docs] Fix floating Kanvas card overlapping navbar (#1187)

### DIFF
--- a/assets/scss/_kanvas-corner-popup.scss
+++ b/assets/scss/_kanvas-corner-popup.scss
@@ -13,17 +13,35 @@
 }
 
 .kanvas-corner-popup .popup {
+  --kanvas-top-gap:1rem;
+  --kanvas-bottom-gap: 3rem;
+  --kanvas-navbar-height: 6rem;
   position: fixed;
   bottom: 0;
   right: 0;
-  margin: 0 2rem 3rem;
+  margin: 0 2rem var(--kanvas-bottom-gap);
   width: 26rem;
+  max-width: calc(100vw - 4rem);
+  box-sizing: border-box;
+  overflow: visible;
   z-index: 9999;
   display: flex;
   justify-content: center;
   opacity: 0;
   transform: translateY(12px);
   transition: opacity 0.35s ease, transform 0.35s ease;
+
+  @media (max-height: 700px) {
+    --kanvas-bottom-gap: 1rem;
+  }
+
+  @media (max-height: 450px) {
+    --kanvas-bottom-gap: 0.5rem;
+  }
+
+  @media (max-width: 767.98px) {
+    --kanvas-navbar-height: 9rem;
+  }
 
   @media (max-width: 1000px) {
     max-width: 22rem;
@@ -48,7 +66,14 @@
 
 .kanvas-corner-popup .popup-inner {
   position: relative;
+  min-height: 0;
   width: 100%;
+  max-height: calc(100vh - var(--kanvas-navbar-height) - var(--kanvas-bottom-gap) - var(--kanvas-top-gap));
+  max-height: calc(100dvh - var(--kanvas-navbar-height) - var(--kanvas-bottom-gap) - var(--kanvas-top-gap));
+  overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  box-sizing: border-box;
   background: #121212;
   display: flex;
   flex-direction: column;
@@ -58,6 +83,10 @@
   border: 1px solid #00d3a9;
   border-radius: 5%;
   box-shadow: 0 0 28px rgba($secondary, 0.55);
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   @media (max-width: 640px) {
     padding: 0.8rem;
@@ -104,6 +133,8 @@
   text-decoration: none;
   color: inherit;
   width: 100%;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .kanvas-corner-popup .popup-text {
@@ -152,6 +183,8 @@
   font-size: 0.95rem;
   border-radius: 4px;
   text-decoration: none;
+  width: auto;
+  max-width: 100%;
   transition: filter 0.2s ease, box-shadow 0.2s ease;
 
   &:hover {


### PR DESCRIPTION

This PR fixes the issue where the floating Kanvas card overlaps the navbar on low-height or landscape viewports.

### Changes
- Adjusted the floating Kanvas card positioning for low-height screens.
- Prevented the card from overlapping the navbar.
- Preserved the existing behavior on normal-sized screens.

Fixes #1187



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
## Demo

https://github.com/user-attachments/assets/0b936e9a-c080-4ce8-93ce-1e3abd2b833e






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved popup responsiveness across different screen heights and mobile widths.
  * Added configurable spacing and navigation height settings.
  * Constrained popup dimensions and enabled scrolling for lengthy content.
  * Prevented links and buttons from overflowing on narrow screens.
  * Hid scrollbars for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->