### PR TITLE
docs(kanvas): document Help and Support provider and identity preconditions

### DIFF
--- a/content/en/cloud/guides/self-hosted/customizing-webhooks.md
+++ b/content/en/cloud/guides/self-hosted/customizing-webhooks.md
@@ -16,7 +16,7 @@ Layer5 Cloud's webhook configurations are managed through environment variables 
 
 ### Step 1: Locate the .env File
 
-Found **.env** files in the `config` directory of your Layer5 Cloud installation. These file contains environment variables that control various aspects of the application, including webhook URLs.
+Find the **.env** file in the `config` directory of your Layer5 Cloud installation. This file contains environment variables that control various aspects of the application, including webhook URLs.
 
 ### Step 2: Define Custom Webhooks in the .env file
 
@@ -29,7 +29,7 @@ Add your custom webhook URLs to the **.env** file by modifying the existing vari
 # Below is the list of webhooks that Layer5 Cloud uses internally.
 # You can replace the values of these variables with your own webhook URLs.
 
-# Triggers when a user fills the help and support form.  
+# Triggers when a user fills the help and support form, in Layer5 Cloud or in Kanvas.  
 WEBHOOK_HELP_AND_SUPPORT="https://your-custom-webhook-url.com/help-support"
 
 # Webhook to send an email notification to the user when they receive a Kanvas entitlement
@@ -40,12 +40,18 @@ WEBHOOK_SIGNUP_REQUEST="https://your-custom-webhook-url.com/signup-request"
 
 ```
 
+{{< alert type="note" title="WEBHOOK_HELP_AND_SUPPORT also receives Kanvas support requests" >}}
+`WEBHOOK_HELP_AND_SUPPORT` is no longer fired only by the Layer5 Cloud Help and Support form. Support requests raised inside [Kanvas](/kanvas/reference/help-and-support) travel from the browser to Meshery Server, which forwards them to your Layer5 Cloud deployment, which in turn fires this same webhook. Both sources deliver the same `memberFormOne` payload shape, so no change to your webhook endpoint is required - expect the additional volume and the new origin.
+
+Because Kanvas's request is relayed through Meshery Server to your remote provider, Kanvas users must be connected to your Layer5 Cloud deployment (or another remote provider) for Help and Support to work at all; under Meshery's local provider the request is rejected as not implemented.
+{{< /alert >}}
+
 It is advisable not to change variable names to avoid potential conflicts. If you are customizing the remote provider to support additional webhooks, you can add new variables following the naming convention starting with WEBHOOK.
 
-### Step 4: Applying the Configuration
+### Step 3: Applying the Configuration
 
 After updating the **.env** file, apply the changes to your Layer5 Cloud installation. This typically involves restarting the services.
 
-### Step 5: Testing the Webhooks
+### Step 4: Testing the Webhooks
 
 Once the configuration is applied, test the webhooks to ensure they are functioning correctly. You can trigger each webhook by performing the associated actions (e.g., filling out the help and support form, triggering a Kanvas entitlement, or processing a signup request).

--- a/content/en/kanvas/reference/help-and-support.md
+++ b/content/en/kanvas/reference/help-and-support.md
@@ -1,0 +1,42 @@
+---
+title: Help and Support
+description: |
+  How Kanvas submits support requests, and the two preconditions - a remote provider and a signed-in identity - that Help and Support requires.
+weight: 20
+---
+
+Kanvas offers a **Help and Support** form for sending a support request to the Layer5 team. You can open it from the Help menu, and from the **Get Help** action in Kanvas's troubleshooting panel.
+
+## How a support request is delivered
+
+A support request never leaves your browser for a third party. Kanvas submits the form to Meshery Server, which forwards it to your provider's support intake:
+
+```
+Kanvas (browser)  ->  Meshery Server extension proxy  ->  Remote provider support webhook
+```
+
+For [Layer5 Cloud](/cloud) that intake is Layer5's support queue. For a self-hosted Layer5 Cloud deployment it is whatever endpoint the operator has configured - see [Customizing Webhooks](/cloud/guides/self-hosted/customizing-webhooks).
+
+## Help and Support requires a remote provider
+
+Because the submission travels through Meshery Server's extension proxy, Help and Support only works when Meshery is connected to a [remote provider](https://docs.meshery.io/extensibility/providers). Under the **local** provider (`None`) Meshery Server has no support intake to forward to, and the request is rejected as *not implemented*.
+
+This puts Help and Support in line with every other Cloud-bound Kanvas capability - [sharing designs and views](/kanvas/designer/sharing), the [catalog](/cloud/concepts/catalog), and resource access - all of which likewise require a remote provider.
+
+**If Help and Support fails under the local provider:** switch Meshery to a remote provider (Meshery UI, **Providers** in the profile menu, then sign in) and submit the request again. If you cannot switch providers, reach the Layer5 team through the [community forum](https://discuss.layer5.io) or [Slack](https://slack.layer5.io) instead.
+
+## Help and Support requires a signed-in identity
+
+Every support request carries the requester's name and email so the team can reply. Kanvas resolves your signed-in profile when you open Help and Support, rather than asking you to retype it:
+
+- While the profile is being fetched, the dialog shows a loading state and the form is not yet available for input.
+- Once the profile resolves, the form appears, pre-addressed with your identity.
+- If the profile cannot be resolved - an expired or degraded session, for example - the form is not shown and nothing is submitted, because a support request with no way to reply is of no use.
+
+**If the form does not appear:** sign in to your provider again, then reopen Help and Support. If it still does not appear, see [Troubleshooting Kanvas](/kanvas/reference/troubleshooting).
+
+## Type of Inquiry
+
+Each request carries a **Type of Inquiry** - one of **Support**, **Community**, **Account**, or **Commercial** - which the support intake uses to route your request. **Support** is selected by default. These are the same categories used by the Layer5 Cloud Help and Support form, so a request raised from Kanvas is triaged exactly like one raised from Layer5 Cloud.
+
+If a submission fails, your subject, description, and type of inquiry are preserved so you can retry without retyping them.

--- a/content/en/kanvas/reference/help-and-support.md
+++ b/content/en/kanvas/reference/help-and-support.md
@@ -11,7 +11,7 @@ Kanvas offers a **Help and Support** form for sending a support request to the L
 
 A support request never leaves your browser for a third party. Kanvas submits the form to Meshery Server, which forwards it to your provider's support intake:
 
-```
+```text
 Kanvas (browser)  ->  Meshery Server extension proxy  ->  Remote provider support webhook
 ```
 
@@ -19,7 +19,7 @@ For [Layer5 Cloud](/cloud) that intake is Layer5's support queue. For a self-hos
 
 ## Help and Support requires a remote provider
 
-Because the submission travels through Meshery Server's extension proxy, Help and Support only works when Meshery is connected to a [remote provider](https://docs.meshery.io/extensibility/providers). Under the **local** provider (`None`) Meshery Server has no support intake to forward to, and the request is rejected as *not implemented*.
+Because the submission travels through Meshery Server's extension proxy, Help and Support only works when Meshery is connected to a [remote provider](https://docs.meshery.io/extensibility/providers). Under the **local** provider (`None`) Meshery Server has no support intake to forward to, and the extension proxy returns `501 Not Implemented`.
 
 This puts Help and Support in line with every other Cloud-bound Kanvas capability - [sharing designs and views](/kanvas/designer/sharing), the [catalog](/cloud/concepts/catalog), and resource access - all of which likewise require a remote provider.
 

--- a/content/en/kanvas/reference/troubleshooting.md
+++ b/content/en/kanvas/reference/troubleshooting.md
@@ -5,6 +5,10 @@ aliases:
   - /meshmap/reference/troubleshooting
 ---
 
+{{< alert type="info" title="Asking for help from within Kanvas" >}}
+Kanvas's **Get Help** action opens the Help and Support form. It requires a remote provider and a resolved signed-in identity - see [Help and Support](/kanvas/reference/help-and-support) if the form does not open or a submission is rejected.
+{{< /alert >}}
+
 ## Meshery Extension
 
 ### Designer Mode


### PR DESCRIPTION
## Description

Documents the Kanvas Help & Support behavior changes shipped in layer5labs/meshery-extensions#4321 (released v1.0.65-2), where support submissions moved from a browser-to-third-party-webhook POST to a Meshery-Server-relayed path (browser -> Meshery Server extension proxy -> Cloud `WEBHOOK_HELP_AND_SUPPORT`).

Three user-visible consequences, each now findable by a user who hits it:

1. **Help and Support requires a remote provider.** The submission traverses Meshery Server's extension proxy, which returns not-implemented under the local provider. New page `content/en/kanvas/reference/help-and-support.md` states this alongside the other Cloud-bound Kanvas features that share the constraint, with remediation.
2. **The form requires a resolved signed-in identity.** The profile is fetched when the dialog opens (loading state shown); if it cannot be resolved the form is withheld and nothing is submitted. Same page, with remediation.
3. **Self-hosted addendum.** `content/en/cloud/guides/self-hosted/customizing-webhooks.md` gains a note that `WEBHOOK_HELP_AND_SUPPORT` now also receives Kanvas-originated tickets, with the same `memberFormOne` payload shape, so no webhook-side change is needed.

Also cross-linked from `Troubleshooting Kanvas`, since Kanvas's **Get Help** action opens this form.

**Out of scope drive-by:** the webhook guide skipped from "Step 2" to "Step 4"; renumbered, and tidied the Step 1 wording.

Text-only; no fabricated screenshots. `hugo` builds clean locally.

Fixes #1192

Signed-off-by: Lee Calcote <7570704+leecalcote@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `.env` configuration and webhook setup steps for self-hosted deployments.
  * Expanded Help and Support webhook guidance, including request routing, provider requirements, testing, and troubleshooting.
  * Added Kanvas Help and Support documentation covering request categories, loading and failure behavior, and form data preservation.
  * Added troubleshooting guidance for the Get Help action, including remote provider and sign-in requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->