### PR TITLE
Fixed heading anchor icon misalignment and heading formatting for Kanvas documentation section

### DIFF
--- a/assets/scss/_elements_project.scss
+++ b/assets/scss/_elements_project.scss
@@ -153,17 +153,16 @@ div.tip {
 
 .heading-link {
   position: relative;
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
 
   .heading-anchor {
+    display: inline-block;
     font-size: 0.6em;
     opacity: 0;
     transform: translateY(2px);
     transition: opacity 0.3s ease, transform 0.3s ease;
     margin-left: 0.25rem;
     text-decoration: none;
+    white-space: nowrap;
   }
 
   &:hover .heading-anchor {

--- a/content/en/cloud/concepts/catalog/_index.md
+++ b/content/en/cloud/concepts/catalog/_index.md
@@ -49,7 +49,7 @@ Catalog content is categorized in a number of ways:
  
 <!-- List design metadata and descriptions here -->
 
-### Publishing from Kanvas 🔗
+### Publishing from Kanvas
 
 To publish a design into the catalog:
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1196.

1. The heading anchor icon (🔗) was previously misaligned on multi-line headings. Now it fixed.


https://github.com/user-attachments/assets/7f977c87-8459-4a18-920e-34a836e44f70


 2. Removed anchor icon from a sub-heading.
<img width="1360" height="647" alt="image" src="https://github.com/user-attachments/assets/087890bb-fe89-4b97-9324-7e1153b8b772" />



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented heading anchor content from wrapping onto multiple lines, improving readability and layout consistency.
  * Simplified heading link alignment for a cleaner appearance.
* **Documentation**
  * Updated the “Publishing from Kanvas” heading by removing the link emoji.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->