### PR TITLE
Fix heading formatting for Kanvas publishing section

### DIFF
--- a/content/en/cloud/concepts/catalog/_index.md
+++ b/content/en/cloud/concepts/catalog/_index.md
@@ -49,7 +49,7 @@ Catalog content is categorized in a number of ways:
  
 <!-- List design metadata and descriptions here -->
 
-### Publishing from Kanvas 🔗
+### Publishing from Kanvas
 
 To publish a design into the catalog:
 


### PR DESCRIPTION
Updated heading formatting for 'Publishing from Kanvas'.

**Notes for Reviewers**

This PR fixes #1198
Removed anchor icon from a sub-heading.
<img width="1360" height="647" alt="image" src="https://github.com/user-attachments/assets/087890bb-fe89-4b97-9324-7e1153b8b772" />





**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
