### PR TITLE
fix: correct duplicated word in tagsets guide (Test PR)

### DIFF
--- a/content/en/cloud/_index.md
+++ b/content/en/cloud/_index.md
@@ -18,7 +18,7 @@ is an identity provider and global console for Kanvas and Meshery deployments wi
 {{< /ecosystem-box >}}
 
 {{< ecosystem-box link="kanvas/_index.md" icon="images/logos/kanvas-icon-color.svg" image="true" class="hidden-highlight-box" title="Kanvas" >}}
-delivers a collaborative experience similar to how Google Workplace transforms the digital work environment and how Figma democratizes UX design tooling. Kanvas simplifies the complexity of Kubernetes and multi-cloud infrastructure management accessible to all. Kanvas provides a visual, multi-player experience that allows you to create, configure, deploy, and manage modern infrastructure with confidence.
+delivers a collaborative experience similar to how Google Workspace transforms the digital work environment and how Figma democratizes UX design tooling. Kanvas simplifies the complexity of Kubernetes and multi-cloud infrastructure management accessible to all. Kanvas provides a visual, multi-player experience that allows you to create, configure, deploy, and manage modern infrastructure with confidence.
 {{< /ecosystem-box >}}
 
 {{% /pageinfo %}}

--- a/content/en/kanvas/designer/tagsets/index.md
+++ b/content/en/kanvas/designer/tagsets/index.md
@@ -30,7 +30,7 @@ Designs support two different types of tags: Labels and Annotations. Labels are 
 {{< alert title="Performance Consideration" type="warning">}}
 Tags are indexed and searchable. However, the performance of design operations may degrade as the number of tags increases. To ensure an optimal user experience, we recommend using tags judiciously and limiting the number of tags used in a design.
 
-Upon loading a design exceeds that exceeds 10 tags within a single design, Kanvas will automatically disable grouping by tags. You can manually enable grouping by tags by clicking the "Group Components" button in the Designer dock.
+Upon loading a design that exceeds 10 tags within a single design, Kanvas will automatically disable grouping by tags. You can manually enable grouping by tags by clicking the "Group Components" button in the Designer dock.
 {{< /alert >}}
 
 {{< alert title="Related Concept">}}


### PR DESCRIPTION
**Notes for Reviewers**

Test PR to validate the PR preview workflows. Change is a minimal typo fix in content/en/kanvas/designer/tagsets/index.md ("exceeds that exceeds" → "that exceeds").
Audit findings (report-only): pull_request_target in labeler.yml, label-commenter.yml, copilot-pr-handler.yml; wait-for-pages-deployment: false present; actions SHA-pinned; Hugo 0.158.0 matches modules; no dead Hugo/Dart Sass code.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the performance warning to clarify that grouping is disabled when a loaded design contains more than 10 tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->