### PR TITLE
[Docs] Document connection/credential access control in environments

### DIFF
--- a/content/en/cloud/concepts/spaces/environments.md
+++ b/content/en/cloud/concepts/spaces/environments.md
@@ -46,6 +46,16 @@ Credentials in an Environment are the keys to securely authenticate and access m
 
 > See "[Credentials](https://docs.meshery.io/concepts/logical/credentials)" in Meshery Docs for more information.
 
+## Access Control for Connections and Credentials
+
+Access to a Connection — and therefore to its associated Credentials — is granted through any of the following, evaluated independently:
+
+1. **Direct ownership** — the Connection's owner (User ID) matches the current user's ID. Ownership grants full read and write access, including deleting the Connection and its Credentials.
+2. **Indirect access through a shared Workspace** — the Connection is assigned to an Environment linked to a Workspace, and the current user belongs to a Team with access to that Workspace. This grants **read-only** access; Team membership alone does not grant the right to modify or delete the Connection or its Credentials.
+3. **The "View All Organizations" key** — a user holding this [key]({{< ref "cloud/concepts/identity-and-security/keys.md" >}}) can access every Connection and Credential across all organizations, bypassing the ownership and Team checks above.
+
+> Designs and Views are governed by a separate mechanism — resource-access mappings — rather than inheriting through Workspace/Team membership. See [Identity and Security → Security Boundaries]({{< ref "cloud/concepts/identity-and-security/_index.md#security-boundaries" >}}) for how these mechanisms fit together.
+
 ## Example: Orbital Labs Environment Setup
 
 The following illustrates how Five and Zara set up multi-cloud environments at Orbital Labs, spanning AWS, GCP, and Azure. See [Meet Five and the Cast]({{< ref "cloud/getting-started/meet-five/_index.md" >}}) for the full seed inventory.


### PR DESCRIPTION
**Notes for Reviewers**

Supersedes and closes #1141.

## Description

Adds an **Access Control for Connections and Credentials** section to `cloud/concepts/spaces/environments.md`, documenting the same topic #1141 set out to cover, but verified directly against the `meshery-cloud` implementation (`server/dao/connection_access.go`) rather than written from assumption. Differences from #1141:

- **Corrects an accuracy gap:** indirect access via Workspace/Team membership is **read-only** in code (`DeleteUserOwnedConnection` and credential delete/update explicitly do not honor it) - #1141 implied it granted full inherited access, including delete.
- **Adds a missing access path:** the "View All Organizations" key, which bypasses the ownership/Team checks entirely - present in code, absent from #1141.
- **Removes an inaccurate claim:** #1141 stated Designs and Views inherit access through the same Workspace/Team chain as Connections/Credentials. They don't - they're governed by a separate resource-access-mapping ACL table that the Connection/Credential code never touches.
- **Addresses the review feedback #1141 left unresolved:** "User ID" instead of "UserID", and the wordy repeated sentence in the indirect-access bullet.
- **Leaves `identity-and-security/_index.md` untouched.** #1141 changed one of its bullets from an em-dash to a parenthetical, which its own review flagged as an inconsistency with the rest of the file rather than an improvement, so that edit isn't carried forward here.

Verified locally: `npm install && hugo --gc` builds cleanly (1604 pages, no broken `{{< ref >}}` links) and the new section's heading anchor and TOC entry render as expected.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on access control for connections and credentials.
  * Clarified direct ownership, workspace/team read-only access, and the “View All Organizations” key bypass.
  * Documented that Designs and Views use separate access mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->