### PR TITLE
fix(ui): Correct image rendering on teams page

### DIFF
--- a/content/en/cloud/concepts/identity-and-security/teams/_index.md
+++ b/content/en/cloud/concepts/identity-and-security/teams/_index.md
@@ -18,7 +18,7 @@ Outside of grouping users together, teams offer control access to workspaces and
 
 The following teams illustrate how organizations use teams to segment access and responsibilities. Follow the full story at [Meet Five and the Cast]({{< ref "cloud/getting-started/meet-five/_index.md" >}}).
 
-<img src='images/team-of-fives.svg' alt="Team of Fives" style="width:120px; float:right; margin-left:1.5rem; margin-bottom:1rem; background:#fff;" />
+<img src='images/team-of-fives.svg' alt="Illustration of seven team members depicting teamwork and distributing reponsibilites" style="width:120px; float:right; margin-left:1.5rem; margin-bottom:1rem; background:#fff;" />
 
 {{< cardpane >}}
 {{% card header="**Infrastructure Team**" %}}

--- a/content/en/cloud/concepts/identity-and-security/teams/_index.md
+++ b/content/en/cloud/concepts/identity-and-security/teams/_index.md
@@ -18,7 +18,7 @@ Outside of grouping users together, teams offer control access to workspaces and
 
 The following teams illustrate how organizations use teams to segment access and responsibilities. Follow the full story at [Meet Five and the Cast]({{< ref "cloud/getting-started/meet-five/_index.md" >}}).
 
-<img src='images/team-of-fives.svg' alt="Illustration of seven team members depicting teamwork and distributing reponsibilites" style="width:120px; float:right; margin-left:1.5rem; margin-bottom:1rem; background:#fff;" />
+<img src='images/team-of-fives.svg' alt="Illustration of seven team members depicting teamwork and distributing responsibilites" style="width:120px; float:right; margin-left:1.5rem; margin-bottom:1rem; background:#fff;" />
 
 {{< cardpane >}}
 {{% card header="**Infrastructure Team**" %}}

--- a/content/en/cloud/concepts/identity-and-security/teams/_index.md
+++ b/content/en/cloud/concepts/identity-and-security/teams/_index.md
@@ -18,7 +18,7 @@ Outside of grouping users together, teams offer control access to workspaces and
 
 The following teams illustrate how organizations use teams to segment access and responsibilities. Follow the full story at [Meet Five and the Cast]({{< ref "cloud/getting-started/meet-five/_index.md" >}}).
 
-<img src='images/team-of-fives.svg' alt="Team of Fives" style="width:120px; float:right; margin-left:1.5rem; margin-bottom:1rem;" />
+<img src='images/team-of-fives.svg' alt="Team of Fives" style="width:120px; float:right; margin-left:1.5rem; margin-bottom:1rem; background:#fff;" />
 
 {{< cardpane >}}
 {{% card header="**Infrastructure Team**" %}}


### PR DESCRIPTION
**Notes for Reviewers**

This PR resolves issue #1207 by correcting the rendering of the "Team of Fives" image on the Teams documentation page. The image has a transparent background and was not displaying correctly against the page's theme.

**Changes Made:**
- Added `background:#fff;` to the inline style of the `img` tag in `content/en/cloud/concepts/identity-and-security/teams/_index.md`.
- This ensures the SVG has a solid white background, making it clearly visible and consistent with similar character profile images used elsewhere in the documentation (as given in reference users page).

**Verification:**
- Visually confirmed that the image now renders correctly on the local development server. Here's a proof: 
<img width="1920" height="1017" alt="image" src="https://github.com/user-attachments/assets/33112cc9-f701-47e3-abb0-8613afa91f60" />





**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Corrected a typo in the team illustration’s alternative text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->