### PR TITLE
fix(ci): correct misleading check-deps message for hugo binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ include .github/build/Makefile.show-help.mk
 
 ## Verify required commands and local dependencies are present.
 check-deps:
-	@echo "Checking if 'npm' and local 'hugo' binary are present..."
+	@echo "Checking if 'npm' is installed and the npm-packaged 'hugo' binary is present..."
 	@command -v npm > /dev/null || { echo "Error: 'npm' not found. Please install Node.js and npm."; exit 1; }
 	@test -x node_modules/.bin/hugo || { echo "Error: Hugo binary not found in node_modules. Please run 'make setup' first."; exit 1; }
 	@echo "Dependencies check passed."


### PR DESCRIPTION
## What this PR does

Fixes the misleading echo message in the `check-deps` Makefile target.

The message previously said:
> Checking if 'npm' and local 'hugo' binary are present...

This is misleading — the actual check verifies the **npm-packaged** Hugo
binary at `node_modules/.bin/hugo` (installed via `make setup`), not a
system-wide/local Hugo installation. The wording made it sound like a
system Hugo binary was still required, which is no longer the case.

## Change

Updated the echo message to:
> Checking if 'npm' is installed and the npm-packaged 'hugo' binary is present...

No logic was changed — only the message text.

## Note for maintainers

This Makefile is a shared template mirrored across:
- `layer5io/docs`
- `meshery/meshery/docs`
- meshery-academy

The same misleading line may exist in the other repos' Makefiles. Happy
to open matching PRs there if desired, but leaving that decision to
maintainers since the comment block notes check-deps guards are
expected to differ per-repo.

Fixes #1211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the dependency check status message to clarify that Hugo is provided as an npm-packaged binary.
  * Dependency validation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->