### PR TITLE
fix: restore default card icons after back-navigation

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -151,6 +151,14 @@ function restoreImage(imgId, originalSrc) {
     var img = document.getElementById(imgId);
     img.src = originalSrc;
 }
+
+window.addEventListener('pageshow', function (event) {
+    if (!event.persisted) return;
+    document.querySelectorAll('.l5btn[data-default]').forEach(function (link) {
+        var img = link.querySelector('img');
+        restoreImage(img.id, link.dataset.default);
+    });
+});
 </script>
 
 <!-- Wave Visualizer Script -->


### PR DESCRIPTION
Fixes #1209

### Changes

`content/en/_index.md`: added a `pageshow` listener that resets each
  card icon to its `data-default` image via the existing `restoreImage`
  helper when the homepage is restored from the back/forward cache.

### Why

On iOS (Safari and Chrome), tapping a card fires `mouseover`, but
`mouseout` never runs because navigation interrupts it. The page is then
restored from WebKit's cache with the hover icon still set, and nothing
resets it. Android is unaffected; this change is a no-op there.

Tested locally with `npm run build`; needs a physical iPhone check on the
preview deployment to confirm the fix.



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation button images now reliably return to their default appearance when revisiting a page, including through browser back and forward navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->