### PR TITLE
docs(cloud): open signup invitation permission and precedence

### DIFF
--- a/content/en/cloud/concepts/identity-and-security/users/user-invitations/index.md
+++ b/content/en/cloud/concepts/identity-and-security/users/user-invitations/index.md
@@ -24,6 +24,12 @@ By default, organizations are **closed**: there is no open registration. A user 
 
 When no default invitation is set, new users who arrive at your organization's registration page are registered as platform users but are **not** automatically added to your organization. They will have no organization membership and no roles until an administrator adds them or they accept an invitation link.
 
+{{< alert type="info" title="Two ways to designate the open signup invitation" >}}
+An organization's open signup invitation can be set in two places: the invitation picker in **Edit Organization**, or the `isDefault` setting on the invitation itself.
+
+The **Edit Organization** selection takes precedence. The `isDefault` marker is used when no selection has been made there, or when the invitation that selection points at no longer exists.
+{{< /alert >}}
+
 {{< alert type="info" title="Roles are not assigned automatically" >}}
 When a user joins an organization via invitation, they receive only the roles explicitly listed on that invitation. If the invitation has no roles configured, the user joins with no role. Use the `roles` field on each invitation to ensure new members receive the correct initial permissions.
 {{< /alert >}}
@@ -79,7 +85,7 @@ After an invitation is created, a notification email is sent only to addresses l
 | `status` | Invitation status: `enabled` = active and usable; `disabled` = inactive (can be re-enabled later). |
 | `name` | A human-readable name used to identify the invitation. |
 | `description` | Additional information about the invitation's purpose, for internal reference. |
-| `isDefault` | When enabled, marks this invitation as the organization's open signup invitation. Users who register through your organization's registration page are automatically enrolled through this invitation, receiving the pre-configured roles and teams. Without a default invitation, the registration page does not automatically add users to the organization. Only one invitation should be designated as the default at a time. |
+| `isDefault` | When enabled, marks this invitation as the organization's open signup invitation. Users who register through your organization's registration page are automatically enrolled through this invitation, receiving the pre-configured roles and teams. Without a default invitation, the registration page does not automatically add users to the organization. Only one invitation can be designated as the default at a time — designating a new one clears the previous. Turning this setting on **or off** requires the **Manage Invitations** permission; editing any other property of an invitation does not, and leaves the setting as it was. |
 
 ### Managing existing invitations
 


### PR DESCRIPTION
## What

Adds two user-visible facts to the Cloud **User Invitations** page that were missing.

## Why

The page already documented `isDefault` as though it worked, and it now genuinely does - layer5io/meshery-cloud made the column persist, where previously it was absent from the invitation INSERT/UPDATE column lists and the control could never take effect. That work added two behaviours a reader needs:

**1. Changing the setting requires a permission - in both directions.**
Turning an organization's open signup invitation on *or off* requires **Manage Invitations**. Editing any other property of an invitation does not, and leaves the setting unchanged. The clearing direction is the easy one to miss: switching open signup off is the same capability as switching it on, and it is now gated the same way.

**2. There are two places to designate it, and one wins.**
The invitation picker in **Edit Organization** takes precedence over the `isDefault` marker. The marker applies when no selection has been made there, or when the invitation that selection points at no longer exists.

Also states explicitly that designating a new default clears the previous one - the page said "only one ... at a time" without saying what happens when you set a second.

## Scope

One file, prose only, no restructuring:
`content/en/cloud/concepts/identity-and-security/users/user-invitations/index.md`

## Related

Documents behaviour from layer5io/meshery-cloud branch `fm/mc-open-invitation-not-processed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how an organization’s open signup invitation is selected.
  * Documented that the Edit Organization selection takes precedence over the invitation’s default setting.
  * Explained default invitation limitations and required permissions for changing the setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->