### PR TITLE
docs(cloud): account consolidation - land the page, corrected to what shipped

### DIFF
--- a/content/en/cloud/concepts/identity-and-security/users/account-consolidation.md
+++ b/content/en/cloud/concepts/identity-and-security/users/account-consolidation.md
@@ -9,56 +9,63 @@ tags: [users]
 
 Layer5 Cloud recognizes one account per verified email address, no matter which method you use to sign in.
 
-## What is changing for me
+## What changed
 
 Previously, signing in with email/password, GitHub, or Google could each create a **separate** account, even when they shared the same email address. This led to a confusing experience: designs, organizations, and workspaces created under one sign-in method would appear to "disappear" when you signed in with another.
 
-Layer5 Cloud is consolidating these previously split accounts in a one-time maintenance operation. For each affected person, all resources will be transferred to a single retained account, including:
+In July 2026, Layer5 Cloud consolidated these previously split accounts in a one-time maintenance operation. For each affected person, all resources were transferred to a single retained account, including:
 
 - Designs and views
-- Workspaces
+- Workspaces and environments
 - Connections and credentials
-- Performance profiles
+- Performance profiles and results
 - Schedules
+- API tokens
 - Organization and team memberships and roles
 
-Duplicate, auto-created "My Organization" organizations with no other members will be removed. Organizations with other members are preserved, and ownership transfers to the retained account. If a connection name collides during the merge, the duplicate is renamed with a " (merged)" suffix so both remain identifiable.
+Anything else a duplicate account owned - owned teams, academy registrations, and resource access grants among them - moved with it.
 
-{{< alert type="info" title="No action required" >}}
-Consolidation rolls out automatically as a maintenance operation. You do not need to do anything, and you keep access to everything you have, under one account. If you sign in with a different method and resources appear to be missing, your accounts may not have been consolidated yet - [contact support]({{< ref "cloud/getting-started/support.md" >}}).
+Organizations were handled separately from that transfer. An organization owned by a duplicate account with no other active members - typically the "My Organization" that Layer5 Cloud creates for every new account - was removed. Any workspace in it that still held content was first re-homed to the retained account's default organization, so no workspace content was lost. An organization that did have other members was preserved, and its ownership transferred to the retained account.
+
+If a connection name collided during the merge, the duplicate was renamed with a `(merged)` suffix - and `(merged, 2)`, `(merged, 3)`, and so on for any further collisions on the same name - so both remain identifiable.
+
+{{< alert type="info" title="Nothing for you to do" >}}
+Consolidation ran automatically as a maintenance operation and is complete. You keep access to everything you had, under one account. If you sign in with a different method and resources appear to be missing, [contact support]({{< ref "cloud/getting-started/support.md" >}}).
 {{< /alert >}}
 
 ## Signing in with multiple methods
 
-Going forward, signing in with email/password, GitHub, or Google using the same **verified** email address always resolves to the same account:
+Signing in with email/password, GitHub, or Google using the same **verified** email address always resolves to the same account:
 
 1. You create an account with `alice@example.com`, whether by setting a password or signing in with GitHub or Google.
 2. Later, you sign in with a different method (for example, Google instead of GitHub) using a provider that returns the same verified email address.
 3. Layer5 Cloud recognizes the verified email address and signs you into your existing account rather than creating a new one.
 
-Your designs, organizations, and workspaces are always available, regardless of which sign-in method you used to create them or which one you use on a given day. For accounts that were previously split across sign-in methods, this applies once the one-time consolidation completes.
+Your designs, organizations, and workspaces are always available, regardless of which sign-in method you used to create them or which one you use on a given day. Each email address is now unique to a single account, so a second account can no longer be created for an address that already belongs to one.
 
 ## Your email addresses
 
-Layer5 Cloud keeps a record of every email address that has ever resolved to your account. Each of these addresses continues to work for:
+Your account has exactly one **primary** email address at a time. That is the address shown on your profile and the one used to identify you.
+
+If your account absorbed a duplicate during consolidation, Layer5 Cloud also keeps a record of the addresses that duplicate used. Each of those addresses continues to work for:
 
 - Accepting invitations sent to that address
 - Role assignments made against that address
 
-Your account has exactly one **primary** email address at a time, shown on your profile. If you have signed in through multiple methods over time, you may see more than one address associated with your account, but only the primary address is used to identify you by default.
+These additional addresses are not displayed in the Layer5 Cloud interface. You can retrieve them for your own account through the API, at `GET /api/identity/users/{userId}/emails`.
 
 ## Wanting separate accounts
 
-After consolidation completes, each email address maps to exactly one account. If you deliberately want separate accounts, for example to keep a testing environment separate from production, use a distinct email address for each account. This is standard behavior for any SaaS platform that supports single sign-on: identity is tied to the verified email address, not to the sign-in method you happen to use that day.
+Each email address maps to exactly one account. If you deliberately want separate accounts, for example to keep a testing environment separate from production, use a distinct email address for each account. This is standard behavior for any SaaS platform that supports single sign-on: identity is tied to the verified email address, not to the sign-in method you happen to use that day.
 
 ## For organization admins: billing impact
 
-If duplicate accounts have inflated the seat count on your organization's subscription, consolidation corrects that seat count downward automatically once it runs. Your subscription quantity updates on the next billing reconciliation cycle after consolidation; you do not need to adjust it manually.
+If duplicate accounts had inflated the seat count on your organization's subscription, consolidation corrected that seat count downward. Layer5 Cloud recounts billable seats automatically on a recurring reconciliation cycle and pushes the corrected quantity to the payment processor, so there is nothing to adjust manually.
 
 {{< alert type="info" title="Minimum-seat plans" >}}
-If your plan is already at its minimum-seat floor, consolidation has no effect on your seat count or billing.
+Billable seats never drop below your plan's minimum. If your plan was already at its minimum-seat floor, consolidation had no effect on your seat count or billing.
 {{< /alert >}}
 
 {{< alert type="info" title="Related reading" >}}
-For how sign-in providers link to your account going forward, see [Account Linking]({{< ref "cloud/concepts/identity-and-security/users/_index.md#account-linking" >}}).
+For how sign-in providers link to your account, see [Account Linking]({{< ref "cloud/concepts/identity-and-security/users/_index.md#account-linking" >}}).
 {{< /alert >}}

--- a/content/en/cloud/concepts/identity-and-security/users/account-consolidation.md
+++ b/content/en/cloud/concepts/identity-and-security/users/account-consolidation.md
@@ -1,7 +1,7 @@
 ---
 title: Account Consolidation
 description: >
-  Layer5 Cloud resolves email/password, GitHub, and Google sign-in to a single account per verified email address.
+  Layer5 Cloud resolves email/password, GitHub sign-in, and Google sign-in to a single account per verified email address.
 weight: 6
 categories: [Identity]
 tags: [users]

--- a/content/en/cloud/concepts/identity-and-security/users/account-consolidation.md
+++ b/content/en/cloud/concepts/identity-and-security/users/account-consolidation.md
@@ -9,11 +9,11 @@ tags: [users]
 
 Layer5 Cloud recognizes one account per verified email address, no matter which method you use to sign in.
 
-## What changed for me
+## What is changing for me
 
 Previously, signing in with email/password, GitHub, or Google could each create a **separate** account, even when they shared the same email address. This led to a confusing experience: designs, organizations, and workspaces created under one sign-in method would appear to "disappear" when you signed in with another.
 
-Layer5 Cloud has consolidated these previously split accounts in a one-time maintenance operation. For each affected person, all resources were transferred to a single retained account, including:
+Layer5 Cloud is consolidating these previously split accounts in a one-time maintenance operation. For each affected person, all resources will be transferred to a single retained account, including:
 
 - Designs and views
 - Workspaces
@@ -22,10 +22,10 @@ Layer5 Cloud has consolidated these previously split accounts in a one-time main
 - Schedules
 - Organization and team memberships and roles
 
-Duplicate, auto-created "My Organization" organizations that had no other members were removed. Organizations with other members were preserved, and ownership transferred to the retained account. If a connection name collided during the merge, the duplicate was renamed with a " (merged)" suffix so both remain identifiable.
+Duplicate, auto-created "My Organization" organizations with no other members will be removed. Organizations with other members are preserved, and ownership transfers to the retained account. If a connection name collides during the merge, the duplicate is renamed with a " (merged)" suffix so both remain identifiable.
 
 {{< alert type="info" title="No action required" >}}
-Consolidation happened automatically. You do not need to do anything, and you keep access to everything you had before, now under one account.
+Consolidation rolls out automatically as a maintenance operation. You do not need to do anything, and you keep access to everything you have, under one account. If you sign in with a different method and resources appear to be missing, your accounts may not have been consolidated yet - [contact support]({{< ref "cloud/getting-started/support.md" >}}).
 {{< /alert >}}
 
 ## Signing in with multiple methods
@@ -36,7 +36,7 @@ Going forward, signing in with email/password, GitHub, or Google using the same 
 2. Later, you sign in with a different method (for example, Google instead of GitHub) using a provider that returns the same verified email address.
 3. Layer5 Cloud recognizes the verified email address and signs you into your existing account rather than creating a new one.
 
-Your designs, organizations, and workspaces are always available, regardless of which sign-in method you used to create them or which one you use on a given day.
+Your designs, organizations, and workspaces are always available, regardless of which sign-in method you used to create them or which one you use on a given day. For accounts that were previously split across sign-in methods, this applies once the one-time consolidation completes.
 
 ## Your email addresses
 
@@ -49,11 +49,11 @@ Your account has exactly one **primary** email address at a time, shown on your 
 
 ## Wanting separate accounts
 
-After consolidation, each email address maps to exactly one account. If you deliberately want separate accounts, for example to keep a testing environment separate from production, use a distinct email address for each account. This is standard behavior for any SaaS platform that supports single sign-on: identity is tied to the verified email address, not to the sign-in method you happen to use that day.
+After consolidation completes, each email address maps to exactly one account. If you deliberately want separate accounts, for example to keep a testing environment separate from production, use a distinct email address for each account. This is standard behavior for any SaaS platform that supports single sign-on: identity is tied to the verified email address, not to the sign-in method you happen to use that day.
 
 ## For organization admins: billing impact
 
-If duplicate accounts previously inflated the seat count on your organization's subscription, consolidation corrects that seat count downward automatically. Your subscription quantity updates on the next billing reconciliation cycle, you don't need to adjust it manually.
+If duplicate accounts have inflated the seat count on your organization's subscription, consolidation corrects that seat count downward automatically once it runs. Your subscription quantity updates on the next billing reconciliation cycle after consolidation; you do not need to adjust it manually.
 
 {{< alert type="info" title="Minimum-seat plans" >}}
 If your plan is already at its minimum-seat floor, consolidation has no effect on your seat count or billing.

--- a/content/en/cloud/concepts/identity-and-security/users/account-consolidation.md
+++ b/content/en/cloud/concepts/identity-and-security/users/account-consolidation.md
@@ -1,0 +1,64 @@
+---
+title: Account Consolidation
+description: >
+  Layer5 Cloud resolves email/password, GitHub, and Google sign-in to a single account per verified email address.
+weight: 6
+categories: [Identity]
+tags: [users]
+---
+
+Layer5 Cloud recognizes one account per verified email address, no matter which method you use to sign in.
+
+## What changed for me
+
+Previously, signing in with email/password, GitHub, or Google could each create a **separate** account, even when they shared the same email address. This led to a confusing experience: designs, organizations, and workspaces created under one sign-in method would appear to "disappear" when you signed in with another.
+
+Layer5 Cloud has consolidated these previously split accounts in a one-time maintenance operation. For each affected person, all resources were transferred to a single retained account, including:
+
+- Designs and views
+- Workspaces
+- Connections and credentials
+- Performance profiles
+- Schedules
+- Organization and team memberships and roles
+
+Duplicate, auto-created "My Organization" organizations that had no other members were removed. Organizations with other members were preserved, and ownership transferred to the retained account. If a connection name collided during the merge, the duplicate was renamed with a " (merged)" suffix so both remain identifiable.
+
+{{< alert type="info" title="No action required" >}}
+Consolidation happened automatically. You do not need to do anything, and you keep access to everything you had before, now under one account.
+{{< /alert >}}
+
+## Signing in with multiple methods
+
+Going forward, signing in with email/password, GitHub, or Google using the same **verified** email address always resolves to the same account:
+
+1. You create an account with `alice@example.com`, whether by setting a password or signing in with GitHub or Google.
+2. Later, you sign in with a different method (for example, Google instead of GitHub) using a provider that returns the same verified email address.
+3. Layer5 Cloud recognizes the verified email address and signs you into your existing account rather than creating a new one.
+
+Your designs, organizations, and workspaces are always available, regardless of which sign-in method you used to create them or which one you use on a given day.
+
+## Your email addresses
+
+Layer5 Cloud keeps a record of every email address that has ever resolved to your account. Each of these addresses continues to work for:
+
+- Accepting invitations sent to that address
+- Role assignments made against that address
+
+Your account has exactly one **primary** email address at a time, shown on your profile. If you have signed in through multiple methods over time, you may see more than one address associated with your account, but only the primary address is used to identify you by default.
+
+## Wanting separate accounts
+
+After consolidation, each email address maps to exactly one account. If you deliberately want separate accounts, for example to keep a testing environment separate from production, use a distinct email address for each account. This is standard behavior for any SaaS platform that supports single sign-on: identity is tied to the verified email address, not to the sign-in method you happen to use that day.
+
+## For organization admins: billing impact
+
+If duplicate accounts previously inflated the seat count on your organization's subscription, consolidation corrects that seat count downward automatically. Your subscription quantity updates on the next billing reconciliation cycle, you don't need to adjust it manually.
+
+{{< alert type="info" title="Minimum-seat plans" >}}
+If your plan is already at its minimum-seat floor, consolidation has no effect on your seat count or billing.
+{{< /alert >}}
+
+{{< alert type="info" title="Related reading" >}}
+For how sign-in providers link to your account going forward, see [Account Linking]({{< ref "cloud/concepts/identity-and-security/users/_index.md#account-linking" >}}).
+{{< /alert >}}


### PR DESCRIPTION
Finishes and lands the Account Consolidation user doc for Layer5 Cloud.

The first two commits are Lee Calcote's original page, written 2026-07-03 and never pushed. They are preserved as-is; the correction rides on top.

## Has consolidation shipped? Yes - fully, in July 2026

The page was written in forward-looking tense ("is consolidating", "will be transferred", "once it runs"). That was accurate on 3 July. The merge ran three days later and is complete.

**Evidence, strongest first:**

1. **The production schema proves the merge finished.** `layer5io/meshery-cloud@master:database/cloud-schema.sql` is regenerated from the *live production* database post-deploy (the `refresh-cloud-schema` step). It contains `users_email_active_uidx` and `user_email_addresses_email_active_uidx` - the Phase 3 `UNIQUE (lower(email)) WHERE deleted_at IS NULL` partial indexes. Migration `20260706220614_enforce_email_uniqueness` guards those with a `DO $$` block that `RAISE EXCEPTION`s if *any* live duplicate-email cluster remains. Their presence in the prod-derived snapshot is only possible if zero duplicates remained. The same snapshot shows `public.users` no longer carries `user_id` (Phase 4).

2. **The maintainer's execution reports on [meshery-cloud#5410](https://github.com/layer5io/meshery-cloud/issues/5410).**
   - "Production consolidation executed (2026-07-06)", prod v1.0.174: 9,452 identities anchored, **1,043 clusters merged**, active users 11,851 -> 11,549, zero live orphans.
   - "Consolidation COMPLETE - residuals cleared + email uniqueness enforced (prod)" (2026-07-06 22:14 UTC): the 80 residual no-identity clusters merged via the new `--by-email` mode; Phase 3 applied to prod with 12,622 primary email rows backfilled and the precondition confirming 0 duplicates. "**0 duplicate-email clusters remain and uniqueness is enforced.**"

3. **Merged PRs:** [#5671](https://github.com/layer5io/meshery-cloud/pull/5671) `--by-email` residual mode (merged 2026-07-06), [#5672](https://github.com/layer5io/meshery-cloud/pull/5672) Phase 3 email uniqueness (merged 2026-07-07), [#5683](https://github.com/layer5io/meshery-cloud/pull/5683) Phase 4 cutover (merged 2026-07-07). Follow-up [#5673](https://github.com/layer5io/meshery-cloud/issues/5673) (graceful 409 on duplicate-email create) is closed and `ErrEmailAlreadyInUse` is live in `server/dao/user_dao.go`.

Note: `docs/plans/handle-account-fragmentation.md` still shows Gate A checkboxes A2-A6 unticked and a header dated 2026-07-06. That plan file is stale relative to what shipped - the issue comments and the prod schema are the authority, per "prefer what merged and shipped over what a plan said was intended". Worth a separate tidy in meshery-cloud; not touched here.

## Claims verified as written

| Claim | Verdict | Where |
|---|---|---|
| Orgs with other members preserved, ownership transferred to the retained account | Correct | `planOrgDecisions` -> `orgTransfer`; `applyOrgDecision` re-points `organizations.owner` |
| Every address that resolved to the account keeps working for **invitation acceptance** and **role assignment** | Correct | `GetUserByEmail` falls back through `user_email_addresses` (`server/dao/user_dao.go:794`); called by the invite path (`handlers/users.go:1367`) and the role-assignment path (`handlers/users.go:4218`) |
| Exactly one **primary** address | Correct | `user_email_addresses_primary_uidx` - `UNIQUE (owner) WHERE is_primary AND deleted_at IS NULL` |
| Seat count corrects downward automatically, updates on the next reconciliation cycle | Correct | Merged-away rows are soft-deleted and drop out of `GetBillableUsersCount` (`u.deleted_at IS NULL AND u.status = 'active'`); `RunSubscriptionQuantityReconciller` ticks every 2h and pushes the new quantity to the payment processor |
| No effect for plans already at their minimum-seat floor | Correct | `GREATEST(count, s.plan_minimum_units)` in `GetBillableUsersCount` |
| Designs/views, workspaces, connections/credentials, performance profiles, schedules, org+team memberships and roles transfer | Correct, but incomplete - see below | `repointTargets` in `server/consolidation/plan.go` |

## Claims corrected

1. **Tense throughout.** Now describes what happened. The "No action required" alert was a pending announcement telling readers to wait for something already done; it is now "Nothing for you to do", stating the operation is complete, and the "your accounts may not have been consolidated yet" escape hatch is gone.

2. **Org removal is not name-scoped.** The doc said duplicate auto-created *"My Organization"* orgs with no other members were removed. `planOrgDecisions` deletes **any** org owned by a merged-away duplicate with zero active members outside the cluster, regardless of name - "My Organization" is what these are in practice, not the criterion. Reworded, with "My Organization" kept as the typical case.

3. **Added a workspace guarantee the doc omitted.** `handleOrgWorkspaces` runs before an org is cascade-deleted: an empty workspace is soft-deleted, a **non-empty one is re-homed to the retained account's default organization**. A reader whose org disappeared needs to know their workspace content did not.

4. **Connection rename was imprecise.** Right in substance; `nextAvailableMergedName` gives the first collision `(merged)` and subsequent ones `(merged, 2)`, `(merged, 3)`, matching case-insensitively. Stated.

5. **Resource list was incomplete.** `repointTargets` also moves **environments** and **API tokens** (`user_tokens`) - both user-visible - plus owned teams, academy registrations, test submissions, filters, invitations, keys/keychains, performance results, and resource access grants. Added environments and API tokens to the list and a catch-all line for the rest.

6. **"Every email address that has ever resolved to your account" was overstated.** `user_email_addresses` only exists from migration `20260703000000` onward and has exactly three writers: signup (`source='signup'`), the consolidation merge (`source='consolidation'`), and the Phase 3 primary backfill (`source='backfill'`). A linked provider later reporting a *different* verified email does **not** add a row (consistent with the Account Linking rules on the parent page). Narrowed to: the primary, plus the addresses an absorbed duplicate used.

7. **"You may see more than one address associated with your account" was wrong.** There is no UI surface for the alias list - `grep` over `ui/` finds no consumer. The only reader is `GET /api/identity/users/{userId}/emails` (`handlers.GetUserEmailAddresses`, self or Provider Admin). The doc now says the extra addresses are not shown in the interface and names the API.

8. **Added the uniqueness guarantee**, which is the durable half of the outcome: email uniqueness is now enforced by the database, so a second account can no longer be created for an address that already belongs to one.

## Unverified claims

None. Every assertion on the page was checked against shipped code in `layer5io/meshery-cloud` at `master`, the prod-derived schema snapshot, or the maintainer's production run reports on #5410.

## Build correctness

- `make build` (Hugo 0.158.0 via `node_modules/.bin/hugo`) compiles clean: 1535 pages, no errors. `npm run build:production` also clean, page present.
- Both `ref` shortcodes resolve. `cloud/getting-started/support.md` -> `/cloud/getting-started/support/`. `cloud/concepts/identity-and-security/users/_index.md#account-linking` -> `.../users/#account-linking`, and `id="account-linking"` is confirmed present in the rendered target (`## Account Linking`, `_index.md:68`).
- `weight: 6` does not collide. Siblings: user-invitations 3, user-management 4, default-permissions 5, **account-consolidation 6**, notification-preferences 20.
- Front matter matches neighbours: `categories: [Identity]`, `tags: [users]`. No `aliases` added - the four siblings carry `/cloud/identity/users/<slug>/` aliases as artifacts of an old URL migration, and this page never existed at that path, so an alias would invent a redirect for a URL that never shipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for consolidating Layer5 Cloud accounts across email/password, GitHub, and Google sign-in methods.
  * Explained how resources, memberships, roles, access grants, organizations, billing seats, and email addresses are handled during consolidation.
  * Documented sign-in behavior, connection-name conflicts, separate-account requirements, automatic completion, and support options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->