### PR TITLE
docs(cloud): open signup at sign-in, and refused invitation edits

### DIFF
--- a/content/en/cloud/concepts/identity-and-security/users/user-invitations/index.md
+++ b/content/en/cloud/concepts/identity-and-security/users/user-invitations/index.md
@@ -98,6 +98,8 @@ From the table you can perform the following management actions on each invitati
 * **Edit Invitation**: Click the pencil icon to open the edit dialog and modify any invitation properties.
 * **Delete Invitation**: Click the trash icon to permanently remove the invitation. This action cannot be undone.
 
+If another administrator deletes an invitation while your edit dialog is open, saving reports that the invitation was not found rather than reporting success. Close the dialog and reload the invitations table to see the current list. Whenever an edit cannot be saved, the dialog reports the specific reason it was refused.
+
 ### Tracking who has accepted an invitation
 
 The **Quota** column in the invitations table always shows the number of users who have accepted an invitation alongside the configured limit — for example, `2 / 5` if a quota is set, or `2 / Unlimited` if no quota is configured. This lets you monitor uptake at a glance.
@@ -115,6 +117,26 @@ When a user clicks an acceptance link and is logged in, the system performs the 
 5. **Adds the user to teams** — the user is added to all teams configured on the invitation.
 
 Role and team assignment failures are non-blocking: the user is still added to the organization even if an individual role or team assignment fails.
+
+### How the open signup invitation is applied at sign-in
+
+The open signup invitation is not limited to first-time registration. It is applied whenever someone signs in through your organization's own address, such as its custom domain, on every sign-in method that address offers, including email and password as well as social sign-in. Someone who already has a Layer5 Cloud account and has never been a member of your organization becomes a member on that sign-in, with the roles and teams the invitation configures.
+
+It is applied only to people who are not already members, which has two consequences worth knowing:
+
+- **Roles and teams are never re-applied to an existing member.** If you remove a role or a team from someone who joined this way, signing in again does not restore it.
+- **Each person is counted once.** Repeated sign-ins by the same person do not increase the invitation's acceptance count or add them to the organization a second time.
+
+{{< alert type="warning" title="When open signup adds nobody" >}}
+A person can sign in successfully and still not join your organization. The open signup invitation is applied only when all of the following hold:
+
+- Its status is `enabled`.
+- Its expiration date has not passed.
+- Its quota has not been reached.
+- The person's email address matches its `emails` list. An empty list matches everyone.
+
+When one of them does not hold, the person signs in as a platform user with no membership and no roles in your organization, and no error is shown to them. Check these four properties first when people who sign in at your organization's address are not appearing under [User Management]({{< ref "cloud/concepts/identity-and-security/users/user-management/index.md" >}}).
+{{< /alert >}}
 
 ### Use cases and examples
 

--- a/content/en/cloud/concepts/identity-and-security/users/user-invitations/index.md
+++ b/content/en/cloud/concepts/identity-and-security/users/user-invitations/index.md
@@ -135,7 +135,7 @@ A person can sign in successfully and still not join your organization. The open
 - Its quota has not been reached.
 - The person's email address matches its `emails` list. An empty list matches everyone.
 
-When one of them does not hold, the person signs in as a platform user with no membership and no roles in your organization, and no error is shown to them. Check these four properties first when people who sign in at your organization's address are not appearing under [User Management]({{< ref "cloud/concepts/identity-and-security/users/user-management/index.md" >}}).
+When one of them does not hold, someone who is not already a member signs in as a platform user with no membership and no roles in your organization, and no error is shown to them. Existing members are unaffected: they keep the membership, roles, and teams they already have. Check these four properties first when people who sign in at your organization's address are not appearing under [User Management]({{< ref "cloud/concepts/identity-and-security/users/user-management/index.md" >}}).
 {{< /alert >}}
 
 ### Use cases and examples


### PR DESCRIPTION
## What

Adds the two user-visible behaviours from [layer5io/meshery-cloud#6002](https://github.com/layer5io/meshery-cloud/pull/6002) that the **User Invitations** page does not yet carry: how the open signup invitation is applied at sign-in, and what an administrator now sees when an invitation edit is refused.

One file, additive prose only, no restructuring:
`content/en/cloud/concepts/identity-and-security/users/user-invitations/index.md`

## Relationship to #1215

[#1215](https://github.com/layer5io/docs/pull/1215) is already open against this same page for the same upstream change, covering the **Manage Invitations** permission on the open signup marker (both directions) and the precedence of the Edit Organization picker over `isDefault`. This PR deliberately does **not** repeat those facts and touches no line #1215 touches, so the two apply in either order. If #1215 is closed rather than merged, its two facts still need a home here.

## Every user-visible change in #6002, and where it landed

| Behaviour in #6002 | Disposition |
|---|---|
| `isDefault` is persisted and read, so the open signup control finally takes effect | **Already correct, no edit.** The page has always described `isDefault` as working. #6002 makes the existing text true rather than stale, so manufacturing a change here would be noise. |
| Open signup is applied on **every** sign-in through the organization's own address, to any non-member, on every sign-in method that address offers | **Added** as *How the open signup invitation is applied at sign-in*. The page framed this as first-time registration only; an existing account signing in at a custom domain is the reported journey #6002 fixes. |
| Applied only to non-members: a member's roles and teams are never re-applied | **Added.** This is what protects an administrator's deliberate removal of a role or team from being undone by the next login. |
| Acceptance is idempotent: one person is appended to the accepted list once, however many times they sign in | **Added**, in the operator's terms: the acceptance count in the **Quota** column does not climb on repeat sign-ins. |
| Ordinary ineligibility (disabled, expired, at quota, email not listed) is a silent skip: the person signs in, joins nothing, sees no error | **Added** as a warning callout with the four properties to check. This is the page's answer to "open signup adds nobody". |
| An invitation update matching no live invitation of the organization answers *not found* instead of a false success | **Added** to *Managing existing invitations*, described as the stale-edit-dialog case an administrator actually hits. |
| The invitation dialog surfaces the server's reason instead of "Unknown error" | **Added** in the same paragraph, as "the dialog reports the specific reason it was refused". |
| Marker changes require **Manage Invitations** in either direction; an omitted `isDefault` preserves the stored value | **Covered by #1215**, not repeated here. |
| Edit Organization picker takes precedence; a picker value naming a deleted invitation falls through to `isDefault` | **Covered by #1215**, not repeated here. |
| A picker value naming *another organization's* invitation also falls through | **Not documented.** It is a misconfiguration an administrator cannot create through the UI, tracked as [meshery-cloud#5994](https://github.com/layer5io/meshery-cloud/issues/5994), and describing it would document a defect as behaviour. |
| Invitation email no longer renders a dangling "invited by " when the inviter cannot be named | **Not documented.** The page shows the email as a screenshot and never quotes that sentence, so there is nothing here that was false. |
| The 404 answered when editing at **All Organizations** scope | **Not documented.** #6002 records this as a held product question, not settled behaviour. |

## On the API contract, corrected

The brief for this work said a newly returned **404** is undeclared in the pinned `meshery/schemas` contract. Checked directly against `schemas/constructs/v1beta3/invitation/api.yml` at **v1.3.44**: `updateInvitation` declares `200/400/401/404/500`, so the 404 **is** in the contract. The undeclared status is the **403** on `createInvitation` and `updateInvitation`, and it is already escalated upstream: [meshery/schemas#1173](https://github.com/meshery/schemas/issues/1173) with the fix open at [meshery/schemas#1174](https://github.com/meshery/schemas/pull/1174).

Nothing here states an HTTP status code either way. These pages describe what an administrator sees, so the refusal is written as behaviour ("reports that the invitation was not found", "reports the specific reason") and no undeclared contract is asserted as fact.

## Testing

- `npm run build` clean: 1623 pages, no shortcode or `ref` errors, and the new `{{</* alert */>}}` and the User Management cross-reference render correctly in `public/`.
- `markdownlint` on the changed file before and after: no new rule classes. The only additions are `MD013` line-length, which every prose line on this page (and the repo) already carries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for handling invitations deleted by another administrator while an edit dialog is being saved.
  - Documented how open signup invitations are applied during sign-in, including eligibility rules, member limits, expiration, disabling, and email matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->