### PR TITLE
docs(cloud): document that member removal ends team access too

### DIFF
--- a/content/en/cloud/concepts/identity-and-security/teams/_index.md
+++ b/content/en/cloud/concepts/identity-and-security/teams/_index.md
@@ -55,6 +55,10 @@ Below the top-level organization, you can add as many teams as you want - at the
 If you are the current team owner, you can’t remove yourself from the team until you transfer ownership to another team administrator.
 {{< /alert >}}
 
+{{< alert type="info" title="Removing a Member from the Organization" >}}
+Removing a member from an organization also ends their membership in that organization's teams, and the permissions those team memberships granted. See [User Management]({{< ref "cloud/concepts/identity-and-security/users/user-management/index.md" >}}).
+{{< /alert >}}
+
 ## Delete a Team
 
 Deleting a team permanently removes the team and its memberships from the organization. This action dissolves the team but does not delete user accounts or associated resources.

--- a/content/en/cloud/concepts/identity-and-security/users/user-management/index.md
+++ b/content/en/cloud/concepts/identity-and-security/users/user-management/index.md
@@ -58,6 +58,31 @@ You can remove users from an organization one by one or several at once. This ac
 
 ![Removing Users from an Organization](images/remove_user.png)
 
+#### What Removal Ends
+
+Removing a member ends every access-bearing relationship they hold **inside that organization**, as a single operation:
+
+* **Their organization membership**, together with the organization [roles]({{< ref "cloud/concepts/identity-and-security/roles/organization-roles.md" >}}) attached to it.
+* **Their membership in that organization's [teams]({{< ref "cloud/concepts/identity-and-security/teams/_index.md" >}})**, together with the team [roles]({{< ref "cloud/concepts/identity-and-security/roles/team-roles.md" >}}) attached to those memberships.
+
+Both matter, because permissions reach a user through the roles carried on those memberships. A [keychain]({{< ref "cloud/concepts/identity-and-security/keychains.md" >}}) granted by a team role is revoked by the removal just as an organization role's keychain is, so a removed member is left holding no [keys]({{< ref "cloud/concepts/identity-and-security/keys.md" >}}) in the organization by either route. Both removal methods above behave identically in this respect; removing several members at once applies the same operation to each one.
+
+Removal does **not** affect:
+
+* The person's Layer5 Cloud user account, which continues to exist.
+* Their membership in any other organization, or in teams belonging to those organizations.
+* Designs, environments, and other resources they created, which remain in the organization.
+
+Removal is not reversible from the Users tab. To restore someone's access, add them to the organization again and reassign their organization roles and team memberships - neither returns on its own.
+
+{{< alert type="warning" title="Team Access Is Not Itemized in the Confirmation" >}}
+The confirmation shown after a removal reports only that the member was removed from the organization. It does not list the team memberships that ended with it. Review the member's teams before removing them if you need a record of what their removal revoked.
+{{< /alert >}}
+
+{{< alert type="info" title="Organization Owners Cannot Be Removed" >}}
+An attempt to remove the organization's owner is rejected. Transfer ownership to another administrator first, then remove the former owner. See [Organization Roles]({{< ref "cloud/concepts/identity-and-security/roles/organization-roles.md" >}}).
+{{< /alert >}}
+
 ## Invite User via Email
 
 You can invite new or existing users to join one of your organizations by sending them an email invitation.

--- a/content/en/cloud/concepts/identity-and-security/users/user-management/index.md
+++ b/content/en/cloud/concepts/identity-and-security/users/user-management/index.md
@@ -73,7 +73,7 @@ Removal does **not** affect:
 * Their membership in any other organization, or in teams belonging to those organizations.
 * Designs, environments, and other resources they created, which remain in the organization.
 
-Removal is not reversible from the Users tab. To restore someone's access, add them to the organization again and reassign their organization roles and team memberships - neither returns on its own.
+Removal is not reversible from the Users tab. To restore someone's access, add them to the organization again and reassign their organization roles and team memberships. Neither returns on its own.
 
 {{< alert type="warning" title="Team Access Is Not Itemized in the Confirmation" >}}
 The confirmation shown after a removal reports only that the member was removed from the organization. It does not list the team memberships that ended with it. Review the member's teams before removing them if you need a record of what their removal revoked.


### PR DESCRIPTION
## What this documents

User-facing companion to layer5io/meshery-cloud#6009, which shipped internal documentation only.

Removing a member from an organization ends **every access-bearing edge inside that organization** - their organization membership *and* their memberships in that organization's teams - through the shared `retireOrganizationEdges` cascade in `server/dao/organizations.go` that both removal paths now call. The Users tab documentation described only the organization half, so an administrator reading it had no reason to believe team-granted permission keys were revoked.

## Changes

- `content/en/cloud/concepts/identity-and-security/users/user-management/index.md` - extends the existing **Removing Users from an Organization** section (the page that already owns member removal; no new page added) with a **What Removal Ends** subsection: what removal revokes, what it leaves untouched, that removal is not reversible from the Users tab, and that organization owners cannot be removed.
- `content/en/cloud/concepts/identity-and-security/teams/_index.md` - a short cross-reference so the Teams concept page points at the removal behaviour.

Front matter, weights, categories/tags, and `ref` shortcode conventions are unchanged and match neighbouring pages. `make build` completes clean; every `ref` resolves.

## Verified against the implementation, not the summary

The behaviour documented here is the one reachable from the Users tab. Both controls the page describes - the row action and the multi-select removal - call `DELETE /api/identity/orgs/:orgId/users/:userId` (`Handlers.RemoveUserFromOrganization`); the multi-select control loops the same per-member call. That path runs the cascade today.

## Limitations deliberately NOT documented, and why

1. **The team cascade is not surfaced in the removal confirmation** (layer5io/meshery-cloud#6004). The server's response describes what was removed, but the UI discards the body and toasts a fixed sentence. This PR therefore never says an administrator is shown or informed of the team removals. Instead it states the opposite plainly, so the page does not create a false expectation:

   > The confirmation shown after a removal reports only that the member was removed from the organization. It does not list the team memberships that ended with it.

   That note should be removed once #6004 lands.

2. **The `/users/bulk` per-organization branch is a silent no-op** (layer5io/meshery-cloud#6005). PR 6009's cascade fix in `DeleteUserFromOrg` is reached only from that branch, which never executes because of the context-key collision at `server/router/router.go:252`. The control that drives it in the UI is **Delete User Account**, which reports success while doing nothing. That control is not documented on this page today and this PR does not add it - documenting it would describe a flow that does not work. Once #6005 is repaired, the same **What Removal Ends** subsection covers it without rewording, since both paths share one cascade.

3. **Row counts are not exposed to users.** The audit description reports team membership *rows*, not teams - a member holding two roles in one team accounts for two rows. Since nothing puts that count in front of an administrator today, this PR does not print a count anywhere rather than risk labelling rows as teams.

Cross-reference: layer5io/meshery-cloud#6009


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that removing a member ends their organization and team memberships, roles, and related permissions.
  * Documented what removal does not affect, including the user account, other organizations, and created resources.
  * Added guidance about irreversible removal, confirmation details, and restrictions on removing organization owners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->