### PR TITLE
docs(catalog): close Catalog Management documentation gaps

### DIFF
--- a/content/en/cloud/concepts/catalog/_index.md
+++ b/content/en/cloud/concepts/catalog/_index.md
@@ -59,6 +59,20 @@ To publish a design into the catalog:
 1. In the design details dialog, review or update the **name**, **type**, and **description**, then click **Publish To Catalog**.
 1. After the request is submitted, maintainers approve it, and the design appears in the [public catalog](https://cloud.layer5.io/catalog).
 
+### Viewing Filters
+
+Your filter list at [My Filters](https://cloud.layer5.io/catalog/content/my-filters) is not limited to filters you created. When you are signed in, it returns:
+
+- every **public** and **published** filter, whoever owns it - including those belonging to other members of your teams;
+- your own **private** filters;
+- any filter that has been shared with you directly.
+
+Private filters belonging to other people are never returned. The one exception is a provider administrator, who can see private content across the provider.
+
+Signed-out visitors browsing someone's public profile see only that person's public and published filters.
+
+Filters can be browsed in grid view or table view, and searched and sorted from either. For the operations you can perform on a filter once you have found it - import, publish, unpublish, clone, download, edit, view details, and delete - see [Envoy WASM Filter Management](https://docs.meshery.io/guides/infrastructure-management/filter-management) in the Meshery documentation.
+
 ### Importing Filters
 
 WebAssembly filters can be brought into Layer5 Cloud in two ways:

--- a/content/en/cloud/concepts/catalog/exploring-the-catalog/index.md
+++ b/content/en/cloud/concepts/catalog/exploring-the-catalog/index.md
@@ -161,10 +161,16 @@ Editing/Unpublish published designs requires specific user roles and permissions
 
 Deletion is not the same as [Unpublish](#unpublish). Unpublishing withdraws a design from the public catalog and keeps it in your account; deleting destroys it, and unassigns it from every workspace it belonged to at the same time. There is no trash and no undo.
 
-You must own the item to delete it, and you need the **Delete a design** permission; a user who holds the permission but does not own the item is still refused. The **Delete** action is disabled when your role does not carry the permission.
+You must own the item to delete it, and you need the delete permission for that item's type; a user who holds the permission but does not own the item is still refused. The permissions are type-specific:
+
+| Catalog item | Permission required |
+| --- | --- |
+| Design | **Delete a design** |
+| WASM filter | **Delete WASM Filter** |
+| View | **Delete View** |
+
+The **Delete** action is disabled when your role does not carry the permission for that item's type. See [Default Permissions]({{< ref "cloud/reference/default-permissions.md" >}}) for which roles hold each of them by default.
 
 The table view of [My Designs](https://cloud.layer5.io/catalog/content/my-designs) also supports deleting several items at once: select rows with their checkboxes and use the bulk **Delete** action. Each selected item is deleted independently, so a failure on one does not stop the others - check the list afterwards.
-
-<!-- SCREENSHOT NEEDED: Layer5 Cloud catalog content list, delete confirmation dialog open for a single catalog item, must show the "Delete Catalog item?" dialog title, the item name in the subtitle, and the Delete and Cancel buttons -->
 
 > For the full walkthrough, including how deletion differs from removing a design from a workspace, see [Deleting a Design]({{< ref "kanvas/tasks/designs/deleting-a-design/index.md" >}}).

--- a/content/en/cloud/concepts/catalog/exploring-the-catalog/index.md
+++ b/content/en/cloud/concepts/catalog/exploring-the-catalog/index.md
@@ -101,7 +101,11 @@ As you scroll down the page, you will find other useful sections:
 
 ### Open in Playground
 
-Clicking **Open in Playground** loads the design directly into [Kanvas](https://kanvas.new/).
+Clicking **Open in Playground** opens the design in the Kanvas designer running at [playground.meshery.io](https://playground.meshery.io/extension/meshmap), in a new browser tab. The catalog page you were on stays open behind it.
+
+The Playground is a hosted, ready-to-use Kanvas instance. It is the fastest way to look inside a catalog design - you can pan, zoom, open components, and inspect relationships without installing Meshery or signing in. Changes you make there are not written back to the catalog design; to keep your own editable copy, [Clone](#clone) it instead.
+
+The link Layer5 Cloud builds carries the design's identifier as URL parameters, so the Playground opens on that specific design rather than an empty canvas. See [URL Parameters]({{< ref "kanvas/advanced/url-parameters/index.md" >}}) for what those parameters mean and how to construct such a link yourself.
 
 ### Clone
 
@@ -150,3 +154,17 @@ If you no longer want a design to be published in the catalog, you can use the *
 {{< alert type="info" title="Permissions Required" >}}
 Editing/Unpublish published designs requires specific user roles and permissions. Learn more: [Default Permissions documentation]({{< ref "cloud/reference/default-permissions.md" >}}).
 {{< /alert >}}
+
+### Delete
+
+**Delete** removes a catalog item permanently. It applies to the catalog content you own - designs, views, and filters - and the confirmation dialog is titled **Delete Catalog item?**.
+
+Deletion is not the same as [Unpublish](#unpublish). Unpublishing withdraws a design from the public catalog and keeps it in your account; deleting destroys it, and unassigns it from every workspace it belonged to at the same time. There is no trash and no undo.
+
+You must own the item to delete it, and you need the **Delete a design** permission; a user who holds the permission but does not own the item is still refused. The **Delete** action is disabled when your role does not carry the permission.
+
+The table view of [My Designs](https://cloud.layer5.io/catalog/content/my-designs) also supports deleting several items at once: select rows with their checkboxes and use the bulk **Delete** action. Each selected item is deleted independently, so a failure on one does not stop the others - check the list afterwards.
+
+<!-- SCREENSHOT NEEDED: Layer5 Cloud catalog content list, delete confirmation dialog open for a single catalog item, must show the "Delete Catalog item?" dialog title, the item name in the subtitle, and the Delete and Cancel buttons -->
+
+> For the full walkthrough, including how deletion differs from removing a design from a workspace, see [Deleting a Design]({{< ref "kanvas/tasks/designs/deleting-a-design/index.md" >}}).

--- a/content/en/kanvas/designer/export-designs/index.md
+++ b/content/en/kanvas/designer/export-designs/index.md
@@ -7,7 +7,7 @@ categories: [Designer]
 tags: [designs, export]
 aliases:
   - /meshmap/designer/export-designs
-# Should this page every be relocated, please create a redirect link from the old location to the new location or backlinks like the one below will break.
+# Should this page ever be relocated, please create a redirect link from the old location to the new location or backlinks like the one below will break.
 # https://github.com/layer5labs/meshery-extensions/tree/master/kanvas/src/components/designer/drawer/ComponentDrawerTabContent/exportModal.js
 #
 # The explicit heading IDs below (#exporting-as-a-design-file, #exporting-as-an-oci-image,
@@ -16,7 +16,7 @@ aliases:
 # ID alongside if a section is retitled.
 ---
 
-Kanvas let's you export a design in several formats, so you can:
+Kanvas lets you export a design in several formats, so you can:
 
 * keep versioned backups  
 * collaborate offline  

--- a/content/en/kanvas/designer/export-designs/index.md
+++ b/content/en/kanvas/designer/export-designs/index.md
@@ -9,6 +9,11 @@ aliases:
   - /meshmap/designer/export-designs
 # Should this page every be relocated, please create a redirect link from the old location to the new location or backlinks like the one below will break.
 # https://github.com/layer5labs/meshery-extensions/tree/master/kanvas/src/components/designer/drawer/ComponentDrawerTabContent/exportModal.js
+#
+# The explicit heading IDs below (#exporting-as-a-design-file, #exporting-as-an-oci-image,
+# #exporting-as-embedding, #exporting-in-a-source-type-format) are linked to from inside the
+# product and from the Features & Permissions sheet. Do not rename or remove them; add a new
+# ID alongside if a section is retitled.
 ---
 
 Kanvas let's you export a design in several formats, so you can:
@@ -40,7 +45,7 @@ Kanvas let's you export a design in several formats, so you can:
 
 ## Detailed Format Guide
 
-### Design (YAML)
+### Design (YAML) {#exporting-as-a-design-file}
 
 Exports a complete, lossless copy of your design.  
 This format preserves all Meshery-specific metadata, including:
@@ -51,7 +56,7 @@ This format preserves all Meshery-specific metadata, including:
 
 Use it to back up or move designs between Meshery instances. The file is saved as `<design-name>.yml`.
 
-### Design (OCI Image)
+### Design (OCI Image) {#exporting-as-an-oci-image}
 
 Exports your design as an OCI-compliant container image.  
 This format preserves all design metadata, just like the Design (YAML), but in a form suitable for container registries.
@@ -64,7 +69,13 @@ When to use:
 
 The exported file is named `<design-name>.tar`, and can be pushed using tools like `docker push` or `oras push`.
 
-### Kubernetes Manifest (YAML)  *Lossy Export*
+### Source-Type Formats {#exporting-in-a-source-type-format}
+
+A design can also be exported back out as the kind of source it was built from. Two source types are supported: **Kubernetes Manifest** and **Helm Chart**. Both are lossy - the Kanvas-specific layout, annotations, and comments are dropped, because neither format has anywhere to carry them.
+
+Docker Compose is an *import* source only. There is no Docker Compose export; converting a design to Compose is not supported.
+
+#### Kubernetes Manifest (YAML)  *Lossy Export* {#exporting-as-a-kubernetes-manifest}
 
 Exports your design as raw Kubernetes YAML files, ready to apply with `kubectl`.
 
@@ -77,7 +88,7 @@ This format strips out Meshery-specific context and includes only standard Kuber
 
 > If you want to preserve the full editable design, use **Design (YAML)** instead.
 
-### Helm Chart (.tar.gz)  *Lossy Export*
+#### Helm Chart (.tar.gz)  *Lossy Export* {#exporting-as-a-helm-chart}
 
 Packages your design as a standard Helm chart archive (`.tar.gz`).
 
@@ -90,7 +101,7 @@ This format includes only Kubernetes resource definitions.  Design layout, annot
 
 > If you want to keep your design fully editable in Meshery, use **Design (YAML)** instead.
 
-### Embed Design (JavaScript Snippet)
+### Embed Design (JavaScript Snippet) {#exporting-as-embedding}
 
 Exporting your design as an embedding allows you to integrate it into websites, blogs, or other platforms that support HTML, CSS, and JavaScript. 
 
@@ -149,6 +160,16 @@ No, login is not required. You can export as a guest user.
   <summary>Can I export someone else's published design?</summary>
   
 Yes. Any published design can be exported, not just your own.
+</details>
+
+<details>
+  <summary>Can I export an earlier version of a design?</summary>
+
+No. Every export - in any format - is generated from the **current** state of the design. A design carries a single version number, which increments as the design is updated, and the export and download endpoints take no version argument.
+
+The **View Save History** button in Kanvas (on the save-status indicator) shows the design's save history as a list of events. It is an audit trail of who changed the design and when; it is not a set of restorable snapshots, and you cannot export from it.
+
+If you need a version you can come back to, export a copy at the point you care about - **Design (YAML)** or **Design (OCI image)** are the two lossless formats - and keep it, or push the OCI image to a registry under a tag.
 </details>
 
 <details>

--- a/content/en/kanvas/getting-started/import-designs/index.md
+++ b/content/en/kanvas/getting-started/import-designs/index.md
@@ -146,6 +146,19 @@ It requires you to authorize the Meshery GitHub App, which then allows you to br
 </details>
 
 <details>
+  <summary>Can I import a design from GitLab or BitBucket?</summary>
+
+Not as a repository connection. GitHub is the only source-code host Meshery integrates with directly: it is the only repository connection kind the platform defines, and the import form itself offers just two upload methods, **File Upload** and **URL Import**.
+
+You can still bring in a design that lives in GitLab or BitBucket, by either route:
+
+- **URL Import** - give the import form a direct URL to the raw file. It must serve the file body itself, not a web page that renders it, and it must be reachable from the public internet.
+- **File Upload** - download the file from your repository first, then upload it. This is the route to use for a self-hosted or otherwise private GitLab or BitBucket server, which Meshery cannot reach.
+
+What you do not get on either route is the persistent, repository-wide connection the GitHub integration provides - browsing repositories from the Meshery UI, and the GitOps workflow that posts visual snapshots of design changes onto pull requests.
+</details>
+
+<details>
   <summary>Is there a file size limit for imported designs?</summary>
   
 There is no strict limit on the file size itself (e.g., in MB). However, there are limits on the number of **components** a design can contain, which is determined by your current subscription plan. Free accounts are limited to 100 components.

--- a/content/en/kanvas/getting-started/import-designs/index.md
+++ b/content/en/kanvas/getting-started/import-designs/index.md
@@ -146,14 +146,14 @@ It requires you to authorize the Meshery GitHub App, which then allows you to br
 </details>
 
 <details>
-  <summary>Can I import a design from GitLab or BitBucket?</summary>
+  <summary>Can I import a design from GitLab or Bitbucket?</summary>
 
 Not as a repository connection. GitHub is the only source-code host Meshery integrates with directly: it is the only repository connection kind the platform defines, and the import form itself offers just two upload methods, **File Upload** and **URL Import**.
 
-You can still bring in a design that lives in GitLab or BitBucket, by either route:
+You can still bring in a design that lives in GitLab or Bitbucket, by either route:
 
 - **URL Import** - give the import form a direct URL to the raw file. It must serve the file body itself, not a web page that renders it, and it must be reachable from the public internet.
-- **File Upload** - download the file from your repository first, then upload it. This is the route to use for a self-hosted or otherwise private GitLab or BitBucket server, which Meshery cannot reach.
+- **File Upload** - download the file from your repository first, then upload it. This is the route to use for a self-hosted or otherwise private GitLab or Bitbucket server, which Meshery cannot reach.
 
 What you do not get on either route is the persistent, repository-wide connection the GitHub integration provides - browsing repositories from the Meshery UI, and the GitOps workflow that posts visual snapshots of design changes onto pull requests.
 </details>

--- a/content/en/kanvas/tasks/designs/deleting-a-design/index.md
+++ b/content/en/kanvas/tasks/designs/deleting-a-design/index.md
@@ -1,0 +1,61 @@
+---
+title: Deleting a Design
+description: >
+  Permanently delete a design you own, and understand how deleting differs from unpublishing a design or removing it from a workspace.
+weight: 6
+categories: [Designer]
+tags: [designs]
+---
+
+Deleting a design removes it permanently. There is no trash, no recycle bin, and no undo: the design record is destroyed, and every workspace it was assigned to loses it at the same time. Before you delete, check that what you actually want is not one of the two softer actions described under [Related actions that are not deletion](#related-actions-that-are-not-deletion).
+
+## Who Can Delete a Design
+
+Deleting a design requires the **Delete a design** permission, and beyond that you must own the design. A user who holds the permission but is not the owner is refused - only the design's owner, or a provider administrator, can delete it.
+
+If the **Delete** action is greyed out for you, your role does not carry the permission. See [Default Permissions]({{< ref "cloud/reference/default-permissions.md" >}}) for which roles hold it by default, and [Keychains]({{< ref "cloud/concepts/identity-and-security/keychains.md" >}}) for how an organization administrator can grant it.
+
+## Deleting a Single Design
+
+1. Go to [My Designs](https://cloud.layer5.io/catalog/content/my-designs) in Layer5 Cloud, or open the design's detail page.
+2. Choose **Delete** from the design's actions.
+3. A confirmation dialog opens, naming the design. Click **Delete** to confirm, or dismiss the dialog to cancel.
+
+<!-- SCREENSHOT NEEDED: Layer5 Cloud My Designs, delete confirmation dialog open for a single design, must show the "Delete Catalog item?" dialog with the design name in the subtitle and the Delete and Cancel buttons -->
+
+Once the deletion succeeds you are returned to **My Designs** and the design is gone from the list.
+
+## Deleting Several Designs at Once
+
+The table view of **My Designs** supports bulk deletion.
+
+1. Switch to table view.
+2. Select the rows you want to delete using the checkboxes.
+3. Choose **Delete** from the bulk actions.
+4. Confirm in the dialog, which names how many designs will be deleted.
+
+<!-- SCREENSHOT NEEDED: Layer5 Cloud My Designs table view, three rows selected with the bulk delete confirmation dialog open, must show the row checkboxes, the bulk action bar, and the "Delete Selected Catalog items?" dialog -->
+
+Each design in the selection is deleted independently. If one of them fails - for example because you do not own it - the rest still go through, so check the list afterwards rather than assuming the whole batch succeeded.
+
+## What Deletion Removes
+
+- The design itself, including its design file, name, and metadata.
+- Its assignment to **every** workspace it belonged to. Collaborators who reached the design through a shared workspace lose access to it, because there is nothing left to reach.
+
+Deleting a design does not affect infrastructure. If the design was deployed, the deployed resources stay running in your clusters. [Undeploy]({{< ref "kanvas/tasks/designs/undeploying-designs/index.md" >}}) the design first if you want its resources removed as well - once the design is deleted, you no longer have the definition Meshery would need in order to undeploy it.
+
+## Related Actions That Are Not Deletion
+
+Two nearby actions are frequently mistaken for deletion. Neither destroys the design.
+
+| Action | What it does | When to use it |
+|---|---|---|
+| **Unpublish** | Removes a design from the public catalog. The design remains in your account as a private design. | You want to withdraw a design from public view but keep it. |
+| **Remove from workspace** | Unassigns the design from one workspace. The design and its other workspace assignments are untouched. | You want to tidy a workspace, not lose the design. |
+
+Removing a design from a workspace is labelled **Delete** in the workspace's design table, and its confirmation dialog says "from workspace *name*". That phrase is the thing to check: if the dialog names a workspace, you are unassigning; if it does not, you are deleting the design outright.
+
+{{< alert type="warning" title="Deletion is permanent" >}}
+There is no recovery path for a deleted design. If you may want the design later, [export it]({{< ref "kanvas/designer/export-designs/index.md" >}}) as a **Design (YAML)** or **Design (OCI image)** file before deleting - both formats are lossless and can be imported back into Kanvas.
+{{< /alert >}}

--- a/content/en/kanvas/tasks/designs/deleting-a-design/index.md
+++ b/content/en/kanvas/tasks/designs/deleting-a-design/index.md
@@ -13,15 +13,13 @@ Deleting a design removes it permanently. There is no trash, no recycle bin, and
 
 Deleting a design requires the **Delete a design** permission, and beyond that you must own the design. A user who holds the permission but is not the owner is refused - only the design's owner, or a provider administrator, can delete it.
 
-If the **Delete** action is greyed out for you, your role does not carry the permission. See [Default Permissions]({{< ref "cloud/reference/default-permissions.md" >}}) for which roles hold it by default, and [Keychains]({{< ref "cloud/concepts/identity-and-security/keychains.md" >}}) for how an organization administrator can grant it.
+If the **Delete** action is grayed out for you, your role does not carry the permission. See [Default Permissions]({{< ref "cloud/reference/default-permissions.md" >}}) for which roles hold it by default, and [Keychains]({{< ref "cloud/concepts/identity-and-security/keychains.md" >}}) for how an organization administrator can grant it.
 
 ## Deleting a Single Design
 
 1. Go to [My Designs](https://cloud.layer5.io/catalog/content/my-designs) in Layer5 Cloud, or open the design's detail page.
 2. Choose **Delete** from the design's actions.
 3. A confirmation dialog opens, naming the design. Click **Delete** to confirm, or dismiss the dialog to cancel.
-
-<!-- SCREENSHOT NEEDED: Layer5 Cloud My Designs, delete confirmation dialog open for a single design, must show the "Delete Catalog item?" dialog with the design name in the subtitle and the Delete and Cancel buttons -->
 
 Once the deletion succeeds you are returned to **My Designs** and the design is gone from the list.
 
@@ -33,8 +31,6 @@ The table view of **My Designs** supports bulk deletion.
 2. Select the rows you want to delete using the checkboxes.
 3. Choose **Delete** from the bulk actions.
 4. Confirm in the dialog, which names how many designs will be deleted.
-
-<!-- SCREENSHOT NEEDED: Layer5 Cloud My Designs table view, three rows selected with the bulk delete confirmation dialog open, must show the row checkboxes, the bulk action bar, and the "Delete Selected Catalog items?" dialog -->
 
 Each design in the selection is deleted independently. If one of them fails - for example because you do not own it - the rest still go through, so check the list afterwards rather than assuming the whole batch succeeded.
 

--- a/content/en/kanvas/tasks/designs/dry-running-a-design/index.md
+++ b/content/en/kanvas/tasks/designs/dry-running-a-design/index.md
@@ -21,8 +21,6 @@ Each component in your design is submitted to the Kubernetes API server of every
 
 3. Select the Kubernetes cluster or clusters you want to simulate against, then run the simulation. If no clusters are selected, the dry run targets all connected clusters.
 
-<!-- SCREENSHOT NEEDED: Kanvas designer, Dry Run modal open on a design with at least one connected Kubernetes cluster, must show the cluster selection and the run control before results are returned -->
-
 4. Review the results to identify any potential issues.
 
 5. Make necessary adjustments to your configuration based on the feedback provided by the dry run.

--- a/content/en/kanvas/tasks/designs/dry-running-a-design/index.md
+++ b/content/en/kanvas/tasks/designs/dry-running-a-design/index.md
@@ -11,17 +11,54 @@ aliases:
 
 A dry run in Meshery simulates the deployment of your design in the selected target environment without making any actual changes. This step is highly beneficial as it helps identify potential issues before they occur, ensuring a smoother and more reliable deployment process.
 
+Each component in your design is submitted to the Kubernetes API server of every selected cluster as a dry-run request. The API server validates the resource exactly as it would on a real apply - schema, field values, admission - and then discards it. Nothing is created, updated, or persisted, so a dry run is safe to repeat as often as you like.
+
 ## Performing Dry Run
 
 1. Navigate to the **Actions** button at the top of the Design canvas.
 
 2. Click on the **Dry Run** icon.
 
-3. Review the results to identify any potential issues.
+3. Select the Kubernetes cluster or clusters you want to simulate against, then run the simulation. If no clusters are selected, the dry run targets all connected clusters.
 
-4. Make necessary adjustments to your configuration based on the feedback provided by the dry run.
+<!-- SCREENSHOT NEEDED: Kanvas designer, Dry Run modal open on a design with at least one connected Kubernetes cluster, must show the cluster selection and the run control before results are returned -->
 
-5. Re-run the dry run to ensure all issues have been resolved.
+4. Review the results to identify any potential issues.
+
+5. Make necessary adjustments to your configuration based on the feedback provided by the dry run.
+
+6. Re-run the dry run to ensure all issues have been resolved.
+
+### Reading the Results
+
+Results are grouped by component, with the number of errors beside each component's name. Expand a component to see its individual errors, each one naming the kind of problem, the field path it was found at, and the message the Kubernetes API server returned.
+
+Click an error to jump straight to the offending field: Kanvas opens that component's configurator with the field in question in view, so you can correct it without hunting for it.
+
+A dry run reports on Kubernetes-configurable components only. Annotation components - text, shapes, comments, and other visual elements - carry no infrastructure and are counted separately in the summary rather than validated.
+
+## Dry Run and Validate
+
+**Validate** and **Dry Run** answer different questions, and a design can pass one while failing the other.
+
+| | Validate | Dry Run |
+|---|---|---|
+| Checks against | The component's own schema, in Meshery | Your live Kubernetes cluster |
+| Catches | Malformed or missing configuration | Everything Validate catches, plus admission failures, missing CRDs, and cluster-specific policy |
+| Needs a cluster | No | Yes |
+
+Validate is the faster loop and needs nothing connected; run it while you are still building. Dry Run is the check to run before you deploy, because it is the only one that involves the cluster you are about to deploy to.
+
+## Dry Run Inside Deploy and Undeploy
+
+You do not have to remember to dry run before deploying: **Dry Run** is a built-in step of both the deploy and the undeploy flow. Starting either from the **Actions** menu opens a stepper that runs **Validate Design**, then **Identify Environments**, then **Dry Run**, before you reach **Finalize** and **Finish**.
+
+Within that step you can also:
+
+- **Include Dependencies** - extend the simulation to the resources your components depend on.
+- **Bypass errors and initiate deployment** - proceed despite reported errors. Use it deliberately; the errors were reported by the cluster you are about to deploy to.
+
+In the undeploy flow the same step simulates removal instead of creation, so you can see what an [undeploy]({{< ref "kanvas/tasks/designs/undeploying-designs/index.md" >}}) would touch before you commit to it.
 
 ## Dry Run Errors
 


### PR DESCRIPTION
## What this is

The Features & Permissions tab of the Meshery Cloud API Endpoints spreadsheet had 34 Catalog Management rows whose Documentation cell was missing, dead, or pointing somewhere other than what the cell's text claimed. This PR closes those gaps: it writes the documentation that was genuinely absent, fixes the defects in the pages the rows point at, and gives the sheet a verified URL for every row.

Every page here was written against the implementation - `meshery/meshery`, `layer5io/meshery-cloud`, and `layer5labs/meshery-extensions` - not from assumption. Every URL below was fetched with `curl -L` and returned 200, except where explicitly marked.

## Documentation column - one row per worklist item

Apply these to the sheet. Anchors marked **(new in this PR)** are created here and go live on merge; the page itself already returns 200 today.

### Catalog (3)

| Row | Feature | URL for the Documentation column |
|---|---|---|
| 12 | Export a copy of a design to your local system | `https://docs.layer5.io/cloud/concepts/catalog/exploring-the-catalog/#download` |
| 15 | Open in Playground | `https://docs.layer5.io/cloud/concepts/catalog/exploring-the-catalog/#open-in-playground` |
| 465 | Delete catalog items | `https://docs.layer5.io/cloud/concepts/catalog/exploring-the-catalog/#delete` **(new in this PR)** |

Row 12 and row 465 were both pointing at, or missing in favour of, the `https://docs.layer5.io/cloud/catalog/` legacy redirect stub. The canonical section is now addressable directly.

### Designs (21)

| Row | Feature | URL for the Documentation column |
|---|---|---|
| 26 | Import a design | `https://docs.layer5.io/kanvas/getting-started/import-designs/` |
| 27 | Import from Kubernetes Manifest | `https://docs.layer5.io/kanvas/getting-started/import-designs/` |
| 28 | Import from Meshery Design (YAML) | `https://docs.layer5.io/kanvas/getting-started/import-designs/` |
| 29 | Import from Helm Chart | `https://docs.layer5.io/kanvas/getting-started/import-designs/` |
| 30 | Import from Docker Compose | `https://docs.layer5.io/kanvas/getting-started/import-designs/` |
| 31 | Import from Meshery Design (OCI Image) | `https://docs.layer5.io/kanvas/getting-started/import-designs/` |
| 32 | Import from K8s Manifest, Helm Chart, or Docker Compose | `https://docs.layer5.io/kanvas/getting-started/import-designs/` |
| 33 | Import from GitHub | `https://docs.layer5.io/cloud/getting-started/github-integration/` |
| 34 | Import from GitLab | `https://docs.layer5.io/kanvas/getting-started/import-designs/#frequently-asked-questions` - **see "Two features do not exist" below** |
| 35 | Import from BitBucket | `https://docs.layer5.io/kanvas/getting-started/import-designs/#frequently-asked-questions` - **see "Two features do not exist" below** |
| 36 | Import from local filesystem | `https://docs.layer5.io/kanvas/getting-started/import-designs/` |
| 38 | Export in source type format | `https://docs.layer5.io/kanvas/designer/export-designs/#exporting-in-a-source-type-format` **(new in this PR)** |
| 39 | Export latest version as Meshery Design (YAML) | `https://docs.layer5.io/kanvas/designer/export-designs/#exporting-as-a-design-file` **(new in this PR)** |
| 40 | Export latest version as Meshery Design (OCI) | `https://docs.layer5.io/kanvas/designer/export-designs/#exporting-as-an-oci-image` **(new in this PR)** |
| 41 | Standard design export (all formats) | `https://docs.layer5.io/kanvas/designer/export-designs/` |
| 42 | Export a design at a specific version | `https://docs.layer5.io/kanvas/designer/export-designs/#frequently-asked-questions` - **see "A third feature does not exist" below** |
| 44 | Publish a design | `https://docs.layer5.io/kanvas/designer/publishing-designs/` |
| 47 | Dry-run / simulate the deployment of a design | `https://docs.layer5.io/kanvas/tasks/designs/dry-running-a-design/` |
| 52 | Delete a design | `https://docs.layer5.io/kanvas/tasks/designs/deleting-a-design/` **(new page in this PR; 404 until merge)** |
| 53 | Evaluate relationships inside a design | `https://docs.layer5.io/kanvas/designer/relationship-evaluation/` |
| 54 | Download a design in OCI or YAML format | `https://docs.layer5.io/kanvas/designer/export-designs/` |

Rows 26-36 were the text/link mismatch cluster: the cells read `.../kanvas/getting-started/import-designs/` while clicking through to `.../kanvas/getting-started/starting-helm/`, `docs.meshery.io/extensions/importing-a-design`, or `docs.meshery.io/guides/configuration-management/importing-designs`. The displayed URL was the correct one throughout; only the hyperlink was stale. Row 33 is the exception - GitHub import is a repository connection, and its own page is the better target.

Rows 39, 40, 53 and 54 all clicked through to `https://docs.layer5.io/meshmap/designer/export-designs/`, a legacy redirect stub. Row 53 was not an export row at all and now points at the relationship evaluation page. Row 44 clicked through to `https://docs.meshery.io/extensions/publishing-a-design`, which 404s.

Row 47 carried `https://github.com/layer5io/docs/pull/513` - a pull request standing in for a page. **That PR was closed without merging**, but the content it was iterating on is published: `https://docs.layer5.io/kanvas/tasks/designs/dry-running-a-design/` returns 200 today. This PR expands that page rather than writing a new one.

### Filters (10)

All ten point at the same page. The eight dead cells read and linked `https://docs.meshery.io/guides/configuration-management/filter-management`, which 404s; the page moved to `infrastructure-management`.

| Row | Feature | URL for the Documentation column |
|---|---|---|
| 18 | View public/published filters of others and own private | `https://docs.layer5.io/cloud/concepts/catalog/#viewing-filters` **(new in this PR)** |
| 55 | Import a filter | `https://docs.meshery.io/guides/infrastructure-management/filter-management` |
| 56 | Publish WASM filter | `https://docs.meshery.io/guides/infrastructure-management/filter-management` |
| 57 | Unpublish WASM filter | `https://docs.meshery.io/guides/infrastructure-management/filter-management` |
| 58 | Download a WASM filter | `https://docs.meshery.io/guides/infrastructure-management/filter-management` |
| 59 | Details of a WASM filter | `https://docs.meshery.io/guides/infrastructure-management/filter-management` |
| 60 | Edit WASM filter | `https://docs.meshery.io/guides/infrastructure-management/filter-management` |
| 61 | Clone WASM filter from catalog | `https://docs.meshery.io/guides/infrastructure-management/filter-management` |
| 62 | Delete WASM filter | `https://docs.meshery.io/guides/infrastructure-management/filter-management` |
| 63 | Import/Unpublish/Publish/Download/Edit/Clone/Delete/Details | `https://docs.meshery.io/guides/infrastructure-management/filter-management` |

**Filters have not been deprecated.** The brief flagged this as worth checking before writing, so it was checked against the source rather than assumed. Every operation is live: `meshery/meshery` still routes `/api/filter`, `/api/filter/catalog`, `/api/filter/catalog/publish`, `/api/filter/catalog/unpublish`, `/api/filter/{id}` (GET and DELETE), `/api/filter/download/{id}` and `/api/filter/clone/{id}`; Meshery UI still ships `pages/configuration/filters.tsx` with its import, publish and clone modals; and Layer5 Cloud still serves `/api/content/filters` and its download route.

Row 18's visibility rule is documented on the Cloud catalog page because it is a Cloud behaviour, not a Meshery one: `CreateVisibilityFilterClause` returns everything with `public` or `published` visibility regardless of owner, plus `private` rows the caller owns, plus rows shared through `resource_access_mappings`. Provider admins are exempted from the ownership restriction.

## Three sheet rows describe features that are not in the product

These are the rows I could not document as working features, because the implementation does not have them. Rather than invent pages, each is answered honestly in an FAQ on the page a reader would look at, and the sheet rows should be reclassified.

**Rows 34 and 35 - import a design from GitLab / from Bitbucket.** No such import source exists. The design import form is generated from `DesignImportRjsfSchemaV1Beta3` in `meshery/schemas`, whose `uploadType` enum is exactly `["File Upload", "URL Import"]`. The only repository-connection kind the platform defines is `github` (`CoreConnectionKinds` is `{meshery, kubernetes, prometheus, grafana, github}`). Neither `gitlab` nor `bitbucket` appears anywhere in the import path of `meshery-cloud`, `meshery`, or `meshery-extensions` - the only hits are unrelated component models and test fixture names. The import-designs FAQ now says so, and points readers at URL Import and File Upload, which do work for files hosted on either service.

**Row 42 - export a design at a specific version.** Not supported. A design carries a single version, which the UI derives per `getVersion()` in `meshery-cloud/ui/utility/designs.ts`: the published version if published, otherwise the version inside the current design file. Neither download path takes a version argument - `getDesignDownloadUrl(id)` builds `/api/content/patterns/download/{id}` from the id alone, and Meshery's `DownloadMesheryPatternHandler` accepts only `export`, `oci` and `pkg`. Kanvas's "View Save History" opens the notification centre filtered to that design's create and update events; it is an audit trail, not a set of restorable snapshots. The export-designs FAQ now states this and suggests keeping lossless exports or OCI tags instead.

## Defects fixed along the way

**Dead anchors linked from inside the product.** `export-designs` had no heading matching the anchors Kanvas links to. Three places in `meshery-extensions` link to `#exporting-as-embedding` (the export modal's help button, its description text, and the comment written into every generated embed snippet), and `meshery-cloud/ui/components/account/feature_data.json` links to `#exporting-as-a-design-file`. Neither anchor existed - the headings were "Embed Design (JavaScript Snippet)" and "Design (YAML)", generating `#embed-design-javascript-snippet` and `#design-yaml`. Users clicking in-product help landed on the page top. Fixed by pinning explicit heading IDs, with a note in the page's frontmatter recording that these IDs are a contract so a future retitle does not silently break them again.

**Docker Compose listed as an export format.** The sheet's row 38 text says source-type export covers "Kubernetes Manifest, Helm Chart, Docker Compose". It does not: `meshkit`'s `NewFormatConverter` returns a converter for `K8sManifest` and `HelmChart` and `ErrUnknownFormat` for everything else, with a test asserting exactly that for `DockerCompose`. Docker Compose is an import source only. The page now says so explicitly, since "I imported Compose, why can't I export it" is the obvious question.

## Out of scope, noted not fixed

- `content/en/kanvas/tasks/designs/cloning-a-design/index.md` and `undeploying-designs/index.md` each carry several hundred lines of commented-out Docsy theme boilerplate ("Bacon ipsum dolor sit amet…") below their real content. Harmless but noisy; worth a cleanup pass across the section.
- The repo has no markdownlint configuration, so `npm run lint` reports MD013, MD004 and MD032 across essentially all existing content. The files in this PR are consistent with that baseline; adding a config is a separate change.

## Screenshots still needed

Written prose is complete. Four images are still wanted. **The 2026-08-28 authenticated capture pass delivered none of them**; the pages are accurate and complete without them.

The `<!-- SCREENSHOT NEEDED: ... -->` markers that previously carried this information have been **removed from the pages** in response to review feedback, so nothing ships with a TODO comment in it. The placement each marker recorded is preserved in the **Goes** column below - that column is the only remaining record of it, so keep this table alive until the shots land.

| # | Page | Goes (exact placement) | Capture | Status |
|---|---|---|---|---|
| 1 | `kanvas/tasks/designs/deleting-a-design` | Under **Deleting a Single Design**, immediately after step 3 | Layer5 Cloud My Designs, single-item delete confirmation dialog open - must show the **Delete Catalog item?** title, the design name in the subtitle, and the Delete / Cancel buttons | Blocked pending the captain: needs a delete dialog opened against real production data |
| 2 | `kanvas/tasks/designs/deleting-a-design` | Under **Deleting Several Designs at Once**, immediately after step 4 | Layer5 Cloud My Designs table view, two or three rows selected, bulk delete dialog open - must show the row checkboxes, the bulk action bar, and the **Delete Selected Catalog items?** dialog naming the count | Blocked, same reason |
| 3 | `cloud/concepts/catalog/exploring-the-catalog` | In the **Delete** section, after the bulk-delete paragraph | The same delete confirmation dialog in the catalog content list | Blocked, same reason; shot 1 can be reused here |
| 4 | `kanvas/tasks/designs/dry-running-a-design` | Under the usage steps, immediately after step 3 | Kanvas designer, Dry Run modal open with a connected cluster, before results return - must show the cluster selection and the run control | Needs a connected Kubernetes cluster |

None of these needs canvas pointer interaction, so none is permanently uncapturable - all four are waiting on access, not on tooling. Shots 1-3 are the same dialog, and the dialog can be dismissed with **Cancel**: the shot is the confirmation prompt, not a completed deletion.

## Verification

- `hugo --gc` builds clean. Hugo fails the build on an unresolved `{{< ref >}}`, so every internal cross-reference added here resolves.
- Every anchor claimed above was confirmed present in the rendered HTML of the local build.
- Every external URL in the tables above was fetched with `curl -sS -L` and returned 200, with two documented exceptions: `kanvas/tasks/designs/deleting-a-design/` is the new page and 404s until this merges, and `kanvas.new` / `playground.meshery.io` are authenticated app surfaces rather than doc pages (they redirect to sign-in for an anonymous fetch).


## Review round

All reviewer items on this PR are addressed in `40a9cf8`:

| Item | Resolution |
|---|---|
| Typos in `export-designs` ("every" / "let's") | Fixed - "ever" and "lets". |
| "BitBucket" brand spelling in `import-designs` | Fixed - "Bitbucket", in all three places on the page, not just the flagged line. |
| Catalog **Delete** section claimed one `Delete a design` permission for every item type | Fixed. Verified against the seeded permission keys in `meshery-cloud/database/migrations/20190402165034_seed_reference_data.postgres.up.sql`: the delete permissions are per type - **Delete a design** (Catalog Management), **Delete WASM Filter** (Catalog Management), **Delete View** (View Management). The section now carries that table plus a link to Default Permissions. |
| `<!-- SCREENSHOT NEEDED -->` comments ship in the source | Accepted. Stripped from all four pages; the placement each one recorded now lives in the **Goes** column of "Screenshots still needed" above. |
| Also fixed unprompted | "greyed out" -> "grayed out" in `deleting-a-design`, matching the rest of the repo, which uses no British spellings here. |

No Kanvas Operator conformance test is documented anywhere in this PR; nothing to remove on that front.