### PR TITLE
Extract yt-embed-container to independent partial

### DIFF
--- a/assets/scss/_videos_project.scss
+++ b/assets/scss/_videos_project.scss
@@ -1,3 +1,5 @@
+@import "yt-embed-container";
+
 .videobtn-wrapper {
     height: 60px;
     width: 60px;
@@ -88,22 +90,4 @@
         opacity: 1;
         width: 35px;
     }
-}
-
-.yt-embed-container {
-    position: relative;
-    padding-bottom: 56.25%;
-    height: 0;
-    overflow: hidden;
-    margin: 2rem 0;
-
-    iframe {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      border:0;
-    }
-
 }

--- a/assets/scss/_yt-embed-container.scss
+++ b/assets/scss/_yt-embed-container.scss
@@ -1,0 +1,18 @@
+// Generic responsive YouTube/iframe embed wrapper.
+
+.yt-embed-container {
+    position: relative;
+    padding-bottom: 56.25%; // 16:9 aspect ratio
+    height: 0;
+    overflow: hidden;
+    margin: 2rem 0;
+
+    iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      border: 0;
+    }
+}


### PR DESCRIPTION
### Description

This PR fixes #1228 
This PR extracts the `.yt-embed-container` class from `assets/scss/_videos_project.scss` into a standalone, dependency-free SCSS partial (`assets/scss/_yt-embed-container.scss`).

The original `_videos_project.scss` file combines:
1. Video card and carousel styles that rely on Layer5-specific SCSS variables (`$white`, `$casper`, etc.).
2. The `.yt-embed-container` responsive wrapper, which uses standard CSS with zero variable dependencies.

By moving `.yt-embed-container` to its own partial and referencing it with `@import "yt-embed-container";`, the exact styling and cascade order are preserved for Layer5 Docs while enabling other consumers (such as `meshery/meshery`) to mount and `@use` the responsive video embed partial via Hugo modules without pulling in Layer5 variables or card components.

### Changes

- Added `assets/scss/_yt-embed-container.scss` containing the generic `.yt-embed-container` responsive iframe styles.
- Removed the `.yt-embed-container` rules from `_videos_project.scss`.
- Imported the new partial from `_videos_project.scss`.
- Kept the existing `.videobtn-wrapper`, `.video`, `.related-videos`, carousel, and other Layer5-specific styles unchanged.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added responsive sizing for embedded videos, preserving a 16:9 aspect ratio across screen sizes.
  - Embedded video frames now fill their containers correctly for a consistent viewing experience.

- **Refactor**
  - Moved video embed styling into a dedicated stylesheet without changing the visible design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->