### PR TITLE
docs(cloud): stop documenting the email config test as an unauthenticated probe

### DIFF
--- a/content/en/cloud/guides/self-hosted/operating/smtp.md
+++ b/content/en/cloud/guides/self-hosted/operating/smtp.md
@@ -27,12 +27,16 @@ LOG_LEVEL=5
 
 ## Testing Email Configuration
 
-### 1. Email Configuration Test Endpoint
+### 1. Email Configuration Test Endpoint (Provider Admin Only) {#1-email-configuration-test-endpoint}
 
-Test the basic email configuration without sending actual emails:
+Check that the four `SMTP_*` values are configured, without sending an email.
+**Both verbs of this endpoint require authentication and the provider admin
+role**, so the `GET` must carry a credential. It validates configuration only -
+it does not dial the SMTP server.
 
 ```bash
-curl -X GET "https://your-domain.com/api/system/email/test"
+curl -X GET "https://your-domain.com/api/system/email/test" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN"
 ```
 
 **Expected Response (Success):**
@@ -40,17 +44,33 @@ curl -X GET "https://your-domain.com/api/system/email/test"
 {
   "status": "success",
   "message": "Email configuration is valid",
-  "timestamp": "1695312000",
-  "smtp_host": "smtp.gmail.com",
-  "smtp_port": "587",
-  "smtp_username": "your-email@domain.com"
+  "timestamp": "1695312000"
 }
 ```
 
-**Expected Response (Error):**
+The response carries the verdict only. It does not report `smtp_host`,
+`smtp_port` or `smtp_username`: those are the deployment's own relay settings,
+and `SMTP_USERNAME` is an email address. Read the configured values from your
+deployment configuration instead.
+
+**Expected Response (Error):** `500 Internal Server Error`, as plain text
+rather than JSON:
+
+```text
+Email configuration verification failed: SMTP configuration error for field 'SMTP_HOST'
+```
+
+**Expected Response (Unauthenticated):** `401 Unauthorized`
 ```json
 {
-  "error": "Email configuration test failed: SMTP_HOST environment variable is not set"
+  "message": "user must be logged in to perform this operation"
+}
+```
+
+**Expected Response (Authenticated, not a provider admin):** `403 Forbidden`
+```json
+{
+  "message": "user you@example.com must be Provider Admin to perform this operation"
 }
 ```
 
@@ -126,7 +146,7 @@ When `LOG_LEVEL=5`, you'll see detailed debug logs for email operations:
 ### 1. SMTP Configuration Validation
 
 ```log
-DEBUG SMTP Configuration Debug host=smtp.gmail.com port=587 username=user@domain.com password_set=true password_length=16
+DEBUG SMTP Configuration Debug host=smtp.gmail.com port=587 username=user@domain.com password_set=true
 ```
 
 ### 2. Template Processing
@@ -254,7 +274,7 @@ Consider setting up monitoring for email-related metrics:
 
 - [ ] Check `LOG_LEVEL` is set to 5 or 6 for debug logging
 - [ ] Verify all SMTP environment variables are configured
-- [ ] Test email configuration using `/api/system/email/test` endpoint
+- [ ] Test email configuration using the provider-admin-only `/api/system/email/test` endpoint, authenticating the request
 - [ ] Check network connectivity to SMTP server
 - [ ] Validate email template files exist and are accessible
 - [ ] Verify recipient email addresses are valid


### PR DESCRIPTION
## Do not merge before the meshery-cloud change lands

This PR describes behaviour that production **does not have yet**. It is the
external-documentation half of a meshery-cloud security fix that is still
unmerged. Merging this first would swap one wrong page for another - operators
would be told the `GET` needs a credential while the deployed endpoint still
answers anyone.

Depends on: the meshery-cloud commit `fix(security): admin-gate the email
configuration test and stop it echoing SMTP identity`
(branch `fm/mc-email-test-endpoint-anonymous-leak`).

## Symptom

`content/en/cloud/guides/self-hosted/operating/smtp.md` showed
`GET /api/system/email/test` being called with **no credential**, and presented
a success body containing `smtp_host`, `smtp_port` and `smtp_username` as normal
output. The troubleshooting checklist pointed operators at that same
unauthenticated probe.

`SMTP_USERNAME` is an email address. The page was not merely stale - it was
documentation for the defect, instructing readers to exercise an
unauthenticated endpoint and presenting its disclosure as expected output.

## Root cause

In meshery-cloud the `GET` was registered bare on `s.e` while its `POST`
sibling, one line below in `server/router/router.go`, already carried
`AuthorizationMiddlewareForAdmin`; and `TestEmailConfigurationHandler` restated
the configuration it had just validated. This page faithfully described that.

## Fix

Verified against the meshery-cloud change itself rather than taken on
description - both verbs now attach `AuthorizationMiddlewareForAdmin`, and the
handler's success body is `status`, `message`, `timestamp` alone.

- The `GET` example now carries `-H "Authorization: Bearer YOUR_JWT_TOKEN"`,
  and the section says both verbs are provider-admin only.
- The success response is the verdict-only shape, with a line saying the three
  fields are deliberately absent and where to read them instead.
- The checklist item no longer sends an operator to an unauthenticated probe.

Two response examples in the same section were also wrong in *shape*, checked
against the same handler. Corrected while rewriting the section rather than
left as newly-adjacent errors:

- the failure path uses `http.Error`, so it answers **500 with plain text**,
  not the JSON object the page showed;
- refusals come from Echo's default error handler as `{"message": ...}` -
  **401** unauthenticated, **403** for a non-admin. Both are now shown, so an
  operator can tell a missing credential from a missing role.

The `password_length=16` field in the SMTP configuration debug log sample is
gone: the same meshery-cloud commit stopped logging the length of
`SMTP_PASSWORD`, since a secret's length narrows a brute-force search and
`password_set` is all that line was diagnosing.

**Left alone deliberately** - the `smtp_username=sender@domain.com` in the
send-failure log sample. It is a server-side log an operator reads from their
own deployment, on the send path rather than the test endpoint, unchanged by
the fix, and implies nothing about what the endpoint returns.

## Anchor preservation

Marking the heading admin-only would have moved its anchor, which is linked
from outside this repository, so the old slug is pinned with
`{#1-email-configuration-test-endpoint}`. Proved by building `master` and this
branch to separate directories and diffing every `<h1>`-`<h6>` `id=` in the
generated page: **no anchor lost, none added.**

## Verification

- `PATH="$PWD/node_modules/.bin:$PATH" hugo` - builds clean, 1643 pages.
- Rendered page inspected: no `smtp_host` / `smtp_port` / `smtp_username` in
  the success example, all fenced blocks parsed (no literal `##`), heading
  anchor unchanged.

## Reported, not fixed (out of the scope given)

- The `POST` section below still documents `{"error": "Unauthorized: provider
  admin role required"}` and two sibling `{"error": ...}` bodies. That handler
  does not emit those shapes either.
- The send-failure sample is labelled `ERROR`; the server logs that line at
  `DEBUG` (`server/handlers/smtp.go`).

Both predate this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that email configuration test requests require authentication and provider administrator access.
  * Documented that GET requests validate configuration without connecting to the SMTP server.
  * Added documentation for `401 Unauthorized` and `403 Forbidden` responses.
  * Updated documented success and error response formats.
  * Removed sensitive password-length details from SMTP debug logging documentation.
  * Expanded troubleshooting guidance for authentication and access requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->