### PR TITLE
docs(cloud): document the operations Layer5 Cloud refuses against platform-provisioned Environments

### DIFF
--- a/content/en/cloud/guides/organizations/org-management/_index.md
+++ b/content/en/cloud/guides/organizations/org-management/_index.md
@@ -63,7 +63,7 @@ By default, your Organization uses Layer5's shared OAuth applications. To overri
 
 -   Use **Add Google**, **Add GitHub**, or **Add OIDC** to register a provider. Each walkthrough displays the exact redirect URI to add to your OAuth application. Saving your first provider switches the Organization to its own identity providers automatically.
 -   Use **Edit** to rotate a provider's credentials, or **Remove** to delete a single provider. Removing your last provider reverts the Organization to Layer5's defaults.
--   Use **Delete All "Identity Providers"** to delete the environment named, "Identity Providers", therein deleting every configured provider at once, reverting to Provider Organization's defaults.
+-   Use **Delete All Identity Providers** to remove every configured provider at once. This deletes the Environment that Layer5 Cloud provisioned to hold them, and the Organization reverts to Layer5's default identity providers.
 
 Every removal asks you to confirm and explains the consequences before it proceeds.
 

--- a/content/en/cloud/guides/workspaces/managing-environments/index.md
+++ b/content/en/cloud/guides/workspaces/managing-environments/index.md
@@ -61,6 +61,12 @@ See [Link Environments to a Workspace]({{< ref "cloud/guides/workspaces/managing
 An Environment can be linked to more than one Workspace, and a Workspace can have more than one Environment. An Environment that appears in no Workspace is still perfectly valid - it simply is not shared with any team yet.
 {{< /alert >}}
 
+{{< alert type="info" title="Managed Environments Cannot Be Linked to a Workspace" >}}
+Linking an Environment that Layer5 Cloud provisioned for your organization - the Environment behind your own identity providers, for instance - to a Workspace is refused. Linking one grants every member of that Workspace's teams read access to the Environment's Connections and the Credentials behind them, and your organization's identity-provider credentials are not shared that way.
+
+Unlinking is not refused. If such an Environment was linked to a Workspace before this restriction existed, you can still remove it from that Workspace.
+{{< /alert >}}
+
 ## Create an Environment
 
 {{< alert type="info" title="Permissions Required" >}}
@@ -105,9 +111,9 @@ The **>>** and **<<** buttons act on the whole list, so they stay disabled until
 **Save** stays disabled until you have actually changed something, and one **Save** commits every addition and removal you made in the dialog together.
 
 {{< alert type="info" title="Some Environments Are Managed for You" >}}
-A few Environments are provisioned for your organization rather than created by someone in it, and they hold configuration the platform itself relies on - the Environment behind your organization's own identity providers is one. Their Connections are managed from the settings page that owns that feature, so assigning or removing Connections here is refused.
+A few Environments are provisioned for your organization by Layer5 Cloud rather than created by someone in it, and they hold organization-level configuration Layer5 Cloud itself relies on - the Environment behind your organization's own identity providers is one. Their Connections are managed from the [Identity Providers tab]({{< ref "cloud/guides/organizations/org-management/_index.md#configuring-identity-providers-bring-your-own-credentials" >}}) of Edit Organization, so assigning or removing Connections here is refused.
 
-You can still open such an Environment and see what belongs to it. Only changes made through this dialog are declined.
+You can still open such an Environment, see what belongs to it, and change its name and description. Only Connection membership, deletion, and linking it to a Workspace are declined.
 {{< /alert >}}
 
 ## Remove Connections from an Environment
@@ -135,9 +141,9 @@ Deleting an Environment does **not** delete the Connections inside it. Connectio
 {{< /alert >}}
 
 {{< alert type="info" title="Managed Environments Cannot Be Deleted Here" >}}
-Deleting an Environment your organization did not create - one provisioned to hold configuration the platform relies on, such as the Environment behind your own identity providers - is refused. Remove the feature's configuration from the settings page that owns it and the Environment is taken away with it.
+Deleting an Environment your organization did not create - one Layer5 Cloud provisioned to hold organization-level configuration, such as the Environment behind your own identity providers - is refused, whether you delete it singly or as part of a bulk selection. Use **Delete All Identity Providers** on the [Identity Providers tab]({{< ref "cloud/guides/organizations/org-management/_index.md#configuring-identity-providers-bring-your-own-credentials" >}}) instead, and the Environment is taken away with the configuration it holds.
 
-This is why deletion is refused rather than simply hidden: an Environment that still holds live configuration should not disappear from a grid where you can see everything else you own.
+This is why deletion is refused rather than the Environment simply being hidden: an Environment that still holds live configuration should not disappear from a grid where you can see everything else you own.
 {{< /alert >}}
 
 While an Environment is bulk-selected its card cannot be flipped and its individual edit and delete icons are suppressed, so the bulk toolbar is the only way to act on it. Clear the selection to get the per-card actions back.

--- a/content/en/cloud/guides/workspaces/managing-environments/index.md
+++ b/content/en/cloud/guides/workspaces/managing-environments/index.md
@@ -104,6 +104,12 @@ The **>>** and **<<** buttons act on the whole list, so they stay disabled until
 
 **Save** stays disabled until you have actually changed something, and one **Save** commits every addition and removal you made in the dialog together.
 
+{{< alert type="info" title="Some Environments Are Managed for You" >}}
+A few Environments are provisioned for your organization rather than created by someone in it, and they hold configuration the platform itself relies on - the Environment behind your organization's own identity providers is one. Their Connections are managed from the settings page that owns that feature, so assigning or removing Connections here is refused.
+
+You can still open such an Environment and see what belongs to it. Only changes made through this dialog are declined.
+{{< /alert >}}
+
 ## Remove Connections from an Environment
 
 Removal is the same dialog in the other direction:
@@ -126,6 +132,12 @@ You can delete a single Environment or several at once.
 
 {{< alert type="danger" title="What Happens When an Environment is Deleted?" >}}
 Deleting an Environment does **not** delete the Connections inside it. Connections that also belong to other Environments continue to belong to those Environments. The Environment is detached from any Workspaces it was linked to, and the resources it made available to those Workspaces stop being available through it.
+{{< /alert >}}
+
+{{< alert type="info" title="Managed Environments Cannot Be Deleted Here" >}}
+Deleting an Environment your organization did not create - one provisioned to hold configuration the platform relies on, such as the Environment behind your own identity providers - is refused. Remove the feature's configuration from the settings page that owns it and the Environment is taken away with it.
+
+This is why deletion is refused rather than simply hidden: an Environment that still holds live configuration should not disappear from a grid where you can see everything else you own.
 {{< /alert >}}
 
 While an Environment is bulk-selected its card cannot be flipped and its individual edit and delete icons are suppressed, so the bulk toolbar is the only way to act on it. Clear the selection to get the per-card actions back.


### PR DESCRIPTION
## What this does

Documents that some Environments are provisioned for an organization by Layer5 Cloud rather than created by someone in it - the Environment behind an organization's own identity providers is the shipping example - and that the interface refuses several operations against them.

Two commits:

1. The original note (recovered onto current master): the Environments page refuses deleting such an Environment and assigning or removing its Connections.
2. Re-verification against `meshery-cloud@master`, plus the corrections that verification turned up.

## Re-verified against the product

Every claim was checked against `origin/master` in meshery-cloud, not against a summary:

| Operation | Behavior | Source |
| --- | --- | --- |
| Delete Environment | refused, 403 | `ErrProvisionedEnvironmentDeletionRefused` (`meshery_cloud-3272`), `server/dao/environment.go:371` |
| Assign Connection | refused, 403 | `ErrEnvironmentConnectionAssignmentRefused` (`meshery_cloud-3270`), `server/dao/environment.go:537` |
| Remove Connection | refused, 403 | same code, `server/dao/environment.go:620` |
| **Link to a Workspace** | **refused, 403** | `ErrProvisionedEnvironmentWorkspaceMappingRefused` (`meshery_cloud-3273`), `server/dao/workspace.go:739` |
| Unlink from a Workspace | allowed, by design | `WorkspaceDAO.RemoveEnvironmentFromWorkspace` carries no purpose predicate |
| Edit name / description | allowed | `UpdateEnvironment` is unguarded |

### What had drifted

The refusal set is **four** operations, not three. The workspace-mapping guard landed in meshery-cloud on 2026-09-05 at 18:02, about an hour after the documentation note was drafted at 16:54, so the note was accurate when written and is not any more. A mapping is a link in the inherited-access chain (`workspaces_environments_mappings` -> `workspaces_teams_mappings`), so linking a managed Environment into a Workspace would grant that Workspace's teams read on its Connections and the identity-provider credential behind them. Unlinking is deliberately left unguarded - it only ever ends access, and it is the remediation for rows written before the guard existed - and the new note says so, since a reader who cannot link will otherwise assume they cannot unlink either.

## Also in this PR (flagged for reviewers)

- **Provider naming.** The recovered commit had written around the product name ("the platform"). This repository is the user-facing documentation for the hosted product, so the name is restored: the branding rule targets the Cloud interface, whose display name resolves per organization, not these docs.
- **Concrete destination.** Both notes now link to the Identity Providers tab rather than describing an unnamed "settings page that owns the feature", and state that a managed Environment can still be renamed - only Connection membership, deletion and Workspace linking are refused.
- **Adjacent correction, out of the original scope.** The Identity Providers bullet on the Organization Management page named the control `Delete All "Identity Providers"` (the button reads **Delete All Identity Providers**) and described the teardown as deleting "the environment named, 'Identity Providers'". Resolution no longer keys on that name - the name-based lookup was the escalation the `purpose` column replaced - and the revert target is Layer5's default identity providers, not "Provider Organization's defaults".

## Verification

- `hugo` builds clean; all three `ref` shortcodes resolve and the `#configuring-identity-providers-bring-your-own-credentials` target anchor exists in the built HTML.
- Built master and this branch to separate directories and diffed the `id=` attribute of every `<h1>`-`<h6>` across both trees: **no anchor changed**, so no external heading link breaks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated identity-provider deletion guidance to explain the **Delete All Identity Providers** action, including its effects on provisioned Environments and default identity providers.
  - Added guidance for managing Layer5-managed Environments, including Workspace linking, Connection membership, deletion limitations, and editable properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->