### PR TITLE
docs: clarify email verification steps

### DIFF
--- a/content/en/cloud/getting-started/getting-started-with-layer5-account.md
+++ b/content/en/cloud/getting-started/getting-started-with-layer5-account.md
@@ -23,7 +23,11 @@ You may choose to either signup with your personal email or any of our supported
 
 ### 2. Verifying your email address
 
-To ensure you can use all the features in your Layer5 plan, verify your email address after signing up for a new account. For more information, see "Verifying your email address."
+After signing up, Layer5 Cloud sends a verification email to the email address associated with your account. The email contains a verification code and a verification link. You can complete your email verification using either method.
+
+If you are using a custom domain for your Layer5 Cloud organization, the verification link stays on your organization's domain instead of redirecting to the default Layer5 Cloud domain.
+
+Verification links sent before the email-verification fix cannot be repaired. Verification links are valid for 720 hours (30 days). If you have an older or expired link, request a new verification email and use the latest verification link.
 
 
 <!-- considering we would want to use 2FA in future

--- a/content/en/cloud/getting-started/getting-started-with-layer5-account.md
+++ b/content/en/cloud/getting-started/getting-started-with-layer5-account.md
@@ -27,7 +27,7 @@ After signing up, Layer5 Cloud sends a verification email to the email address a
 
 If you are using a custom domain for your Layer5 Cloud organization, the verification link stays on your organization's domain instead of redirecting to the default Layer5 Cloud domain.
 
-Verification links sent before the email-verification fix cannot be repaired. Verification links are valid for 720 hours (30 days). If you have an older or expired link, request a new verification email and use the latest verification link.
+On custom domains, verification links sent before the email-verification fix cannot be completed. Verification links are valid for 720 hours (30 days). If you have a pre-fix link on a custom domain or an expired link, request a new verification email and use the latest verification link.
 
 
 <!-- considering we would want to use 2FA in future


### PR DESCRIPTION
## Notes for Reviewers

This PR updates the Cloud getting-started documentation to clarify the email verification process.

* Explains verification using the verification code or link.
* Clarifies the behavior of verification links when using a custom domain.
* Adds guidance for older or expired verification links.

This PR fixes layer5io/docs#1239

**Signed commits**

* [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that a verification email is sent to the account’s email address.
  - Documented that custom-domain verification links remain on the organization’s domain.
  - Documented the 720-hour validity period and guidance for requesting new links when links are outdated or expired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->